### PR TITLE
feat: add single document snapshot on stream

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -64,4 +64,9 @@ class MockDocumentReference extends Mock implements DocumentReference {
     rootParent.remove(documentID);
     return Future.value();
   }
+
+  @override
+  Stream<DocumentSnapshot> snapshots({bool includeMetadataChanges = false}) {
+    return Stream.value(MockDocumentSnapshot(_documentId, root));
+  }
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -98,6 +98,18 @@ void main() {
             })
           ])));
     });
+    test('Snapshots returns a Stream of Snapshot', () async {
+      final instance = MockFirestoreInstance();
+      await instance.collection('users').document(uid).setData({
+        'name': 'Bob',
+      });
+      expect(
+          instance.collection('users').document(uid).snapshots(),
+          emits(DocumentSnapshotMatcher('abc', {
+            'name': 'Bob',
+          })));
+    });
+
     test('Snapshots returns a Stream of Snapshots upon each change', () async {
       final instance = MockFirestoreInstance();
       expect(


### PR DESCRIPTION
https://github.com/atn832/cloud_firestore_mocks/pull/4/commits/c684c1407e183750e6f1720e9f2b431cf1e0f445

```dart
firestore
      .collection('userProfiles')
      .document(datumId)
      .snapshot()
```

Before:  return `null`
After:  return `Stream<DocumentSnapshot>`
