### PR TITLE
set DocumentSnapshot exists property

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -4,8 +4,10 @@ import 'package:mockito/mockito.dart';
 class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
   final String _documentId;
   final Map<String, dynamic> _document;
+  final bool _exists;
 
-  MockDocumentSnapshot(this._documentId, this._document);
+  MockDocumentSnapshot(this._documentId, this._document)
+      : _exists = _document.isNotEmpty;
 
   @override
   String get documentID => _documentId;
@@ -17,4 +19,7 @@ class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
 
   @override
   Map<String, dynamic> get data => _document;
+
+  @override
+  bool get exists => _exists;
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -110,6 +110,37 @@ void main() {
           })));
     });
 
+    test(
+        'Snapshots sets exists property to false if the document does not exist',
+        () async {
+      final instance = MockFirestoreInstance();
+      await instance.collection('users').document(uid).setData({
+        'name': 'Bob',
+      });
+      instance
+          .collection('users')
+          .document('doesnotexist')
+          .snapshots()
+          .listen(expectAsync1((document) {
+        expect(document.exists, equals(false));
+      }));
+    });
+
+    test('Snapshots sets exists property to true if the document does  exist',
+        () async {
+      final instance = MockFirestoreInstance();
+      await instance.collection('users').document(uid).setData({
+        'name': 'Bob',
+      });
+      instance
+          .collection('users')
+          .document(uid)
+          .snapshots()
+          .listen(expectAsync1((document) {
+        expect(document.exists, equals(true));
+      }));
+    });
+
     test('Snapshots returns a Stream of Snapshots upon each change', () async {
       final instance = MockFirestoreInstance();
       expect(
@@ -387,5 +418,26 @@ class DocumentSnapshotMatcher implements Matcher {
     final snapshot = item as DocumentSnapshot;
     return equals(snapshot.documentID).matches(_documentId, matchState) &&
         equals(snapshot.data).matches(_data, matchState);
+  }
+}
+
+class EmptyDocumentSnapshotMatcher implements Matcher {
+  @override
+  Description describe(Description description) {
+    return StringDescription("Matches a snapshot's exists");
+  }
+
+  @override
+  Description describeMismatch(
+      item, Description mismatchDescription, Map matchState, bool verbose) {
+    if (!equals(item.exists).matches(item, matchState)) {
+      return StringDescription('Exists property is null');
+    }
+  }
+
+  @override
+  bool matches(item, Map matchState) {
+    final snapshot = item as DocumentSnapshot;
+    return equals(snapshot.exists).matches(item, matchState);
   }
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -420,24 +420,3 @@ class DocumentSnapshotMatcher implements Matcher {
         equals(snapshot.data).matches(_data, matchState);
   }
 }
-
-class EmptyDocumentSnapshotMatcher implements Matcher {
-  @override
-  Description describe(Description description) {
-    return StringDescription("Matches a snapshot's exists");
-  }
-
-  @override
-  Description describeMismatch(
-      item, Description mismatchDescription, Map matchState, bool verbose) {
-    if (!equals(item.exists).matches(item, matchState)) {
-      return StringDescription('Exists property is null');
-    }
-  }
-
-  @override
-  bool matches(item, Map matchState) {
-    final snapshot = item as DocumentSnapshot;
-    return equals(snapshot.exists).matches(item, matchState);
-  }
-}


### PR DESCRIPTION
Ran into an issue where if I was using the `exists` property in code I was testing it would throw a run time error because `exists` is defined as a bool but since its never initialized the value returned is null. This PR sets the `exists` property to true if there is data at the path or false if not. Thank you for this library its really really helpful!