### PR TITLE
Fix breakage from API change in cloud_firestore 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0
+
+- fixed breakage due to `FieldValue.type` and `FieldValue.value` being removed from the public API at [cloud_firestore 0.10.0](https://pub.dev/packages/cloud_firestore#0100).
+- implemented chainable `Query.where`. Thank you [qwales1](https://github.com/qwales1)!
+- dropped support for `FieldValue.delete()`.
+
 ## 0.2.7
 
 - implemented `DocumentSnapshot.exists`. Thank you [qwales1](https://github.com/qwales1)!

--- a/example/ios/Runner/GeneratedPluginRegistrant.m
+++ b/example/ios/Runner/GeneratedPluginRegistrant.m
@@ -10,8 +10,8 @@
 @import cloud_firestore;
 #endif
 
-#if __has_include(<firebase_core/FirebaseCorePlugin.h>)
-#import <firebase_core/FirebaseCorePlugin.h>
+#if __has_include(<firebase_core/FLTFirebaseCorePlugin.h>)
+#import <firebase_core/FLTFirebaseCorePlugin.h>
 #else
 @import firebase_core;
 #endif

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the cloud_firestore_mocks plugin.
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^0.13.0+1
+  cloud_firestore: ^0.13.1+1
   firebase_core: "^0.4.0"
 
 dev_dependencies:

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 
 import 'mock_document_reference.dart';
 import 'mock_document_snapshot.dart';
@@ -14,6 +15,8 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
   final Map<String, dynamic> root;
   final Map<String, dynamic> snapshotStreamControllerRoot;
   String currentChildId = '';
+
+  final CollectionReferencePlatform _delegate = null;
 
   StreamController<QuerySnapshot> get snapshotStreamController {
     if (!snapshotStreamControllerRoot.containsKey(snapshotsStreamKey)) {

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:mockito/mockito.dart';
 
 import 'mock_collection_reference.dart';
@@ -14,6 +15,8 @@ class MockDocumentReference extends Mock implements DocumentReference {
   MockDocumentReference(this._documentId, this.root, this.rootParent,
       this.snapshotStreamControllerRoot);
 
+  final DocumentReferencePlatform _delegate = null;
+
   @override
   String get documentID => _documentId;
 
@@ -27,11 +30,8 @@ class MockDocumentReference extends Mock implements DocumentReference {
   Future<void> updateData(Map<String, dynamic> data) {
     data.forEach((key, value) {
       if (value is FieldValue) {
-        // Disabling the warning because the mocks are supposed to run in tests.
-        // ignore: invalid_use_of_visible_for_testing_member
-        switch (value.type) {
-          // ignore: invalid_use_of_visible_for_testing_member
-          case FieldValueType.delete:
+        switch (value.toString()) {
+          case 'FieldValueType.delete':
             root.remove(key);
             break;
           default:

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:mockito/mockito.dart';
 
 import 'mock_snapshot.dart';
@@ -9,6 +10,8 @@ class MockQuery extends Mock implements Query {
   List<DocumentSnapshot> documents;
 
   MockQuery(this.documents);
+
+  final QueryPlatform _delegate = null;
 
   @override
   Future<QuerySnapshot> getDocuments({Source source = Source.serverAndCache}) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -13,8 +13,7 @@ dynamic myEncode(dynamic item) {
   } else if (item is Timestamp) {
     return item.toDate().toIso8601String();
   } else if (item is FieldValue) {
-    // ignore: invalid_use_of_visible_for_testing_member
-    return item.type.toString();
+    return item.toString();
   }
   return item;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^0.13.0+1
+  cloud_firestore: ^0.13.1+1
+  cloud_firestore_platform_interface: ^1.0.0
   mockito: ^4.1.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_firestore_mocks
 description: Mocks for Cloud Firestore. Use this package to write unit tests involving Cloud Firestore.
-version: 0.2.7
+version: 0.3.0
 homepage: http://blog.wafrat.com
 author: atn832@gmail.com
 repository: https://github.com/atn832/cloud_firestore_mocks


### PR DESCRIPTION
https://pub.dev/packages/cloud_firestore#0100 removed `FieldValue.type` and `FieldValue.value` from the public API. So the mocks can't read their values anymore. To fix the breakage more quickly, I'll remove support for `FieldValue.delete()` for now.