### PR TITLE
Mock FieldValue.serverTimestamp() with Timestamp.now()

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -31,10 +31,16 @@ class MockDocumentReference extends Mock implements DocumentReference {
   Future<void> updateData(Map<String, dynamic> data) {
     data.forEach((key, value) {
       if (value is FieldValue) {
-        final fieldValuePlatform = FieldValuePlatform.getDelegate(value) as MockFieldValuePlatform;
+        final valueDelegate = FieldValuePlatform.getDelegate(value);
+        final fieldValuePlatform = valueDelegate as MockFieldValuePlatform;
         switch (fieldValuePlatform.value) {
           case MockFieldValue.delete:
             root.remove(key);
+            break;
+          case MockFieldValue.serverTimestamp:
+            // In real Firestore, it's server-side timestamp,
+            // but mock tests don't have a server.
+            root[key] = Timestamp.now();
             break;
           default:
             throw Exception('Not implemented');

--- a/lib/src/mock_field_value_factory_platform.dart
+++ b/lib/src/mock_field_value_factory_platform.dart
@@ -7,4 +7,8 @@ class MockFieldValueFactoryPlatform extends Mock with MockPlatformInterfaceMixin
   FieldValuePlatform delete() {
     return MockFieldValuePlatform(MockFieldValue.delete);
   }
+
+  FieldValuePlatform serverTimestamp() {
+    return MockFieldValuePlatform(MockFieldValue.serverTimestamp);
+  }
 }

--- a/lib/src/mock_field_value_platform.dart
+++ b/lib/src/mock_field_value_platform.dart
@@ -3,7 +3,8 @@ import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 enum MockFieldValue {
-  delete
+  delete,
+  serverTimestamp,
 }
 
 // Mock implementation of a FieldValue. We store values as a simple string.

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -382,6 +382,21 @@ void main() {
     final users = await instance.collection('users').getDocuments();
     expect(users.documents.isEmpty, equals(true));
   });
+
+    test('serverTimestamp', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('users').document(uid).setData({
+      'username': 'Bob',
+      'created' : FieldValue.serverTimestamp(),
+    });
+    final users = await instance.collection('users').getDocuments();
+    final bob = users.documents.first;
+    expect(bob['created'], isNotNull);
+    final bobCreated = bob['created'] as DateTime;
+    final timeDiff = DateTime.now().difference(bobCreated);
+    // Mock is fast. It shouldn't take 1000 milliseconds to execute the code above
+    expect(timeDiff.inMilliseconds, lessThan(1000));
+  });
 }
 
 class QuerySnapshotMatcher implements Matcher {

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -383,19 +383,21 @@ void main() {
     expect(users.documents.isEmpty, equals(true));
   });
 
-    test('serverTimestamp', () async {
-    final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
-      'username': 'Bob',
-      'created' : FieldValue.serverTimestamp(),
+  test('serverTimestamp', () async {
+    final firestore = MockFirestoreInstance();
+    firestore.setupFieldValueFactory();
+
+    await firestore.collection('users').document(uid).setData({
+      'created': FieldValue.serverTimestamp(),
     });
-    final users = await instance.collection('users').getDocuments();
+    final users = await firestore.collection('users').getDocuments();
     final bob = users.documents.first;
     expect(bob['created'], isNotNull);
-    final bobCreated = bob['created'] as DateTime;
-    final timeDiff = DateTime.now().difference(bobCreated);
+    final bobCreated = bob['created'] as Timestamp; // Not DateTime
+    final timeDiff = Timestamp.now().millisecondsSinceEpoch -
+        bobCreated.millisecondsSinceEpoch;
     // Mock is fast. It shouldn't take 1000 milliseconds to execute the code above
-    expect(timeDiff.inMilliseconds, lessThan(1000));
+    expect(timeDiff, lessThan(1000));
   });
 }
 


### PR DESCRIPTION
Fixes #12 .