### PR TITLE
Auto ID for document()

### DIFF
--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
@@ -31,8 +32,21 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
             .map((entry) => MockDocumentSnapshot(entry.key, entry.value))
             .toList());
 
+  static final Random _random = Random();
+  static final String _autoIdCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  static String _generateAutoId() {
+    final maxIndex = _autoIdCharacters.length - 1;
+    final autoId = List<int>.generate(20, (_) => _random.nextInt(maxIndex))
+      .map((i) => _autoIdCharacters[i]).join();
+    return autoId;
+  }
+
   @override
   DocumentReference document([String path]) {
+    if (path == null) {
+      path = _generateAutoId();
+    }
+
     return MockDocumentReference(path, getSubpath(root, path), root,
         getSubpath(snapshotStreamControllerRoot, path));
   }

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -13,9 +13,6 @@ class MockDocumentReference extends Mock implements DocumentReference {
   final Map<String, dynamic> rootParent;
   final Map<String, dynamic> snapshotStreamControllerRoot;
 
-  // add, setData changes this to true. delete sets false.
-  bool saved = false;
-
   MockDocumentReference(this._documentId, this.root, this.rootParent,
       this.snapshotStreamControllerRoot);
 

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -13,6 +13,9 @@ class MockDocumentReference extends Mock implements DocumentReference {
   final Map<String, dynamic> rootParent;
   final Map<String, dynamic> snapshotStreamControllerRoot;
 
+  // add, setData changes this to true. delete sets false.
+  bool saved = false;
+
   MockDocumentReference(this._documentId, this.root, this.rootParent,
       this.snapshotStreamControllerRoot);
 


### PR DESCRIPTION
Fixes #14 .

Due to complexity in updating tests, I left the behavior of `document.add` unchanged. For example, https://github.com/atn832/cloud_firestore_mocks/pull/22/files#diff-e8ee19ddcfe4302627bdf8313dad3f9bR280 Expecting document ID “zz”