### PR TITLE
Flutter format

### DIFF
--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -33,11 +33,13 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
             .toList());
 
   static final Random _random = Random();
-  static final String _autoIdCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  static final String _autoIdCharacters =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   static String _generateAutoId() {
     final maxIndex = _autoIdCharacters.length - 1;
     final autoId = List<int>.generate(20, (_) => _random.nextInt(maxIndex))
-      .map((i) => _autoIdCharacters[i]).join();
+        .map((i) => _autoIdCharacters[i])
+        .join();
     return autoId;
   }
 

--- a/lib/src/mock_field_value_factory_platform.dart
+++ b/lib/src/mock_field_value_factory_platform.dart
@@ -3,7 +3,9 @@ import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
 import 'package:mockito/mockito.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-class MockFieldValueFactoryPlatform extends Mock with MockPlatformInterfaceMixin implements FieldValueFactoryPlatform {
+class MockFieldValueFactoryPlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements FieldValueFactoryPlatform {
   FieldValuePlatform delete() {
     return MockFieldValuePlatform(MockFieldValue.delete);
   }

--- a/lib/src/mock_field_value_platform.dart
+++ b/lib/src/mock_field_value_platform.dart
@@ -8,7 +8,9 @@ enum MockFieldValue {
 }
 
 // Mock implementation of a FieldValue. We store values as a simple string.
-class MockFieldValuePlatform extends Mock with MockPlatformInterfaceMixin implements FieldValuePlatform {
+class MockFieldValuePlatform extends Mock
+    with MockPlatformInterfaceMixin
+    implements FieldValuePlatform {
   final MockFieldValue value;
 
   MockFieldValuePlatform(this.value);

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -88,12 +88,8 @@ void main() {
     test('FieldValue.delete() deletes key values', () async {
       final firestore = MockFirestoreInstance();
       firestore.setupFieldValueFactory();
-      await firestore.document('root').setData({
-        'flower': 'rose'
-      });
-      await firestore.document('root').setData({
-        'flower': FieldValue.delete()
-      });
+      await firestore.document('root').setData({'flower': 'rose'});
+      await firestore.document('root').setData({'flower': FieldValue.delete()});
       final document = await firestore.document('root').get();
       expect(document.data.isEmpty, equals(true));
     });


### PR DESCRIPTION
Once this PR is merged, I can run "flutter format" to format my changes without touching other files.

```
~/Documents/cloud_firestore_mocks $ flutter format
Formatting directory .:
Formatted test/cloud_firestore_mocks_test.dart
Unchanged example/test_driver/cloud_firestore_test.dart
Unchanged example/test_driver/cloud_firestore.dart
Unchanged example/test/widget_test.dart
Unchanged example/lib/main.dart
Unchanged lib/cloud_firestore_mocks.dart
Unchanged lib/src/util.dart
Formatted lib/src/mock_field_value_factory_platform.dart
Unchanged lib/src/mock_document_reference.dart
Formatted lib/src/mock_field_value_platform.dart
Unchanged lib/src/cloud_firestore_mocks_base.dart
Unchanged lib/src/write_task.dart
Unchanged lib/src/mock_query.dart
Formatted lib/src/mock_collection_reference.dart
Unchanged lib/src/mock_document_snapshot.dart
Unchanged lib/src/mock_write_batch.dart
Unchanged lib/src/mock_snapshot.dart

```