### PR TITLE
addData to use automatic documentID generation

### DIFF
--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -15,7 +15,6 @@ const snapshotsStreamKey = '_snapshots';
 class MockCollectionReference extends MockQuery implements CollectionReference {
   final Map<String, dynamic> root;
   final Map<String, dynamic> snapshotStreamControllerRoot;
-  String currentChildId = '';
 
   // ignore: unused_field
   final CollectionReferencePlatform _delegate = null;
@@ -56,16 +55,14 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
 
   @override
   Future<DocumentReference> add(Map<String, dynamic> data) {
-    while (currentChildId.isEmpty || root.containsKey(currentChildId)) {
-      currentChildId += 'z';
-    }
+    final childId = _generateAutoId();
     final keysWithDateTime = data.keys.where((key) => data[key] is DateTime);
     for (final key in keysWithDateTime) {
       data[key] = Timestamp.fromDate(data[key]);
     }
-    root[currentChildId] = data;
+    root[childId] = data;
     fireSnapshotUpdate();
-    return Future.value(document(currentChildId));
+    return Future.value(document(childId));
   }
 
   @override

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -13,28 +13,6 @@ const expectedDumpAfterSetData = """{
   }
 }""";
 
-const expectedDumpAfterAddData = """{
-  "messages": {
-    "z": {
-      "content": "hello!",
-      "uid": "abc"
-    }
-  }
-}""";
-
-const expectedDumpAfterSuccessiveAddData = """{
-  "messages": {
-    "z": {
-      "content": "hello!",
-      "uid": "abc"
-    },
-    "zz": {
-      "content": "there!",
-      "uid": "abc"
-    }
-  }
-}""";
-
 const uid = 'abc';
 
 void main() {
@@ -48,16 +26,35 @@ void main() {
     });
     test('Add adds data', () async {
       final instance = MockFirestoreInstance();
-      await instance.collection('messages').add({
+      final doc1 = await instance.collection('messages').add({
         'content': 'hello!',
         'uid': uid,
       });
-      expect(instance.dump(), equals(expectedDumpAfterAddData));
-      await instance.collection('messages').add({
+      expect(doc1.documentID, hasLength(20));
+      expect(instance.dump(), equals("""{
+  "messages": {
+    "${doc1.documentID}": {
+      "content": "hello!",
+      "uid": "abc"
+    }
+  }
+}"""));
+      final doc2 = await instance.collection('messages').add({
         'content': 'there!',
         'uid': uid,
       });
-      expect(instance.dump(), equals(expectedDumpAfterSuccessiveAddData));
+      expect(instance.dump(), equals("""{
+  "messages": {
+    "${doc1.documentID}": {
+      "content": "hello!",
+      "uid": "abc"
+    },
+    "${doc2.documentID}": {
+      "content": "there!",
+      "uid": "abc"
+    }
+  }
+}"""));
     });
   });
   test('nested calls to setData work', () async {
@@ -148,7 +145,7 @@ void main() {
     expect(
         instance.collection('users').snapshots(),
         emits(QuerySnapshotMatcher([
-          DocumentSnapshotMatcher('z', {
+          DocumentSnapshotMatcher.onData({
             'name': 'Bob',
           })
         ])));
@@ -170,7 +167,7 @@ void main() {
     expect(
         instance.collection('messages').snapshots(),
         emits(QuerySnapshotMatcher([
-          DocumentSnapshotMatcher('z', {
+          DocumentSnapshotMatcher.onData({
             'content': 'hello!',
             'uid': uid,
             'timestamp': Timestamp.fromDate(now),

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -30,7 +30,7 @@ void main() {
         'content': 'hello!',
         'uid': uid,
       });
-      expect(doc1.documentID, hasLength(20));
+      expect(doc1.documentID.length, greaterThanOrEqualTo(20));
       expect(instance.dump(), equals("""{
   "messages": {
     "${doc1.documentID}": {
@@ -345,7 +345,7 @@ void main() {
 
     final snapshot2 = await firestore.collection('users').document().get();
     expect(snapshot2, isNotNull);
-    expect(snapshot2.documentID.length, 20);
+    expect(snapshot2.documentID.length, greaterThanOrEqualTo(20));
     expect(snapshot2.exists, false);
   });
 }

--- a/test/document_snapshot_matcher.dart
+++ b/test/document_snapshot_matcher.dart
@@ -2,10 +2,16 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:test/test.dart';
 
 class DocumentSnapshotMatcher implements Matcher {
+  // This may be null if no need to match ID
   String _documentId;
   Map<String, dynamic> _data;
 
   DocumentSnapshotMatcher(this._documentId, this._data);
+
+  /// Matcher for data only, without matching documentId.
+  static onData(Map<String, dynamic> data) {
+    return DocumentSnapshotMatcher(null, data);
+  }
 
   @override
   Description describe(Description description) {
@@ -17,7 +23,8 @@ class DocumentSnapshotMatcher implements Matcher {
       item, Description mismatchDescription, Map matchState, bool verbose) {
     final snapshot = item as DocumentSnapshot;
     // TODO: generate more meaningful descriptions.
-    if (!equals(snapshot.documentID).matches(_documentId, matchState)) {
+    if (_documentId != null &&
+        !equals(snapshot.documentID).matches(_documentId, matchState)) {
       equals(snapshot.documentID).describeMismatch(
           _documentId, mismatchDescription, matchState, verbose);
     }
@@ -31,6 +38,9 @@ class DocumentSnapshotMatcher implements Matcher {
   @override
   bool matches(item, Map matchState) {
     final snapshot = item as DocumentSnapshot;
+    if (_documentId == null) {
+      return equals(snapshot.data).matches(_data, matchState);
+    }
     return equals(snapshot.documentID).matches(_documentId, matchState) &&
         equals(snapshot.data).matches(_data, matchState);
   }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -196,5 +196,4 @@ void main() {
       expect(snapshot.documents.first.data['tag'], equals('mostrecent'));
     }));
   });
-
 }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -24,7 +24,7 @@ void main() {
                 isGreaterThan: now.subtract(Duration(seconds: 1)))
             .snapshots(),
         emits(QuerySnapshotMatcher([
-          DocumentSnapshotMatcher('z', {
+          DocumentSnapshotMatcher.onData({
             'content': 'hello!',
             'uid': uid,
             'timestamp': Timestamp.fromDate(now),
@@ -63,11 +63,11 @@ void main() {
             .where('timestamp', isLessThanOrEqualTo: now)
             .snapshots(),
         emits(QuerySnapshotMatcher([
-          DocumentSnapshotMatcher('z', {
+          DocumentSnapshotMatcher.onData({
             'content': 'before',
             'timestamp': Timestamp.fromDate(before),
           }),
-          DocumentSnapshotMatcher('zz', {
+          DocumentSnapshotMatcher.onData({
             'content': 'during',
             'timestamp': Timestamp.fromDate(now),
           }),
@@ -85,7 +85,7 @@ void main() {
             .where('timestamp', isLessThan: now)
             .snapshots(),
         emits(QuerySnapshotMatcher([
-          DocumentSnapshotMatcher('z', {
+          DocumentSnapshotMatcher.onData({
             'content': 'before',
             'timestamp': Timestamp.fromDate(before),
           }),
@@ -102,11 +102,11 @@ void main() {
             .where('timestamp', isGreaterThanOrEqualTo: now)
             .snapshots(),
         emits(QuerySnapshotMatcher([
-          DocumentSnapshotMatcher('zz', {
+          DocumentSnapshotMatcher.onData({
             'content': 'during',
             'timestamp': Timestamp.fromDate(now),
           }),
-          DocumentSnapshotMatcher('zzz', {
+          DocumentSnapshotMatcher.onData({
             'content': 'after',
             'timestamp': Timestamp.fromDate(after),
           }),


### PR DESCRIPTION
Fixes #23

- addData to use automatic documentID generation
- New `DocumentSnapshotMatcher.onData` to create a matcher that does not verify documentID.