### PR TITLE
Assert the number of segment in MockFirestoreInstance's document() and collection()

### DIFF
--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -23,7 +23,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
 
   @override
   CollectionReference collection(String path) {
-    var segments = path.split('/');
+    final segments = path.split('/');
     assert(segments.length % 2 == 1,
         'Invalid document reference. Collection references must have an odd number of segments');
     return MockCollectionReference(this, path, getSubpath(_root, path),
@@ -32,7 +32,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
 
   @override
   DocumentReference document(String path) {
-    var segments = path.split('/');
+    final segments = path.split('/');
     // The actual behavior of Firestore for an invalid number of segments
     // differs by platforms. This library imitates it with assert.
     // https://github.com/atn832/cloud_firestore_mocks/issues/30

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -23,14 +23,28 @@ class MockFirestoreInstance extends Mock implements Firestore {
 
   @override
   CollectionReference collection(String path) {
+    var segments = path.split('/');
+    assert(segments.length % 2 == 1,
+        'Invalid document reference. Collection references must have an odd number of segments');
     return MockCollectionReference(this, path, getSubpath(_root, path),
         getSubpath(_snapshotStreamControllerRoot, path));
   }
 
   @override
   DocumentReference document(String path) {
-    final documentId = path.split('/').last;
-    return MockDocumentReference(this, path, documentId, getSubpath(_root, path), _root,
+    var segments = path.split('/');
+    // The actual behavior of Firestore for an invalid number of segments
+    // differs by platforms. This library imitates it with assert.
+    // https://github.com/atn832/cloud_firestore_mocks/issues/30
+    assert(segments.length % 2 == 0,
+        'Invalid document reference. Document references must have an even number of segments');
+    final documentId = segments.last;
+    return MockDocumentReference(
+        this,
+        path,
+        documentId,
+        getSubpath(_root, path),
+        _root,
         getSubpath(_snapshotStreamControllerRoot, path));
   }
 

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -510,7 +510,7 @@ void main() {
     // https://github.com/atn832/cloud_firestore_mocks/issues/30
     try {
       firestore.document('users');
-      fail('firestore.document should detect invalid segment length');
+      fail('firestore.document should fail upon invalid segment length');
     } on AssertionError catch (_) {
       // pass
     }
@@ -518,8 +518,7 @@ void main() {
     // subcollection
     try {
       firestore.document('users/1234/friends');
-      fail(
-          'firestore.document should detect invalid segment length for subcollection');
+      fail('firestore.document should fail upon invalid segment length');
     } on AssertionError catch (_) {
       // pass
     }
@@ -532,15 +531,14 @@ void main() {
     // document, not a collection.
     try {
       firestore.collection('users/1234');
-      fail('firestore.document should detect invalid segment length');
+      fail('firestore.document should fail upon invalid segment length');
     } on AssertionError catch (_) {
       // pass
     }
 
     try {
       firestore.collection('users/1234/friends/567');
-      fail(
-          'firestore.document should detect invalid segment length for subcollection');
+      fail('firestore.document should fail upon invalid segment length');
     } on AssertionError catch (_) {
       // pass
     }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -529,18 +529,10 @@ void main() {
 
     // This should fail because users/1234 (2 segments) is a reference to a
     // document, not a collection.
-    try {
-      firestore.collection('users/1234');
-      fail('firestore.document should fail upon invalid segment length');
-    } on AssertionError catch (_) {
-      // pass
-    }
+    expect(() => firestore.collection('users/1234'),
+        throwsA(isA<AssertionError>()));
 
-    try {
-      firestore.collection('users/1234/friends/567');
-      fail('firestore.document should fail upon invalid segment length');
-    } on AssertionError catch (_) {
-      // pass
-    }
+    expect(() => firestore.collection('users/1234/friends/567'),
+        throwsA(isA<AssertionError>()));
   });
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -267,9 +267,11 @@ void main() {
   group('FieldValue', () {
     test('FieldValue.delete() deletes key values', () async {
       final firestore = MockFirestoreInstance();
-      await firestore.document('root').setData({'flower': 'rose'});
-      await firestore.document('root').setData({'flower': FieldValue.delete()});
-      final document = await firestore.document('root').get();
+      await firestore.document('root/foo').setData({'flower': 'rose'});
+      await firestore
+          .document('root/foo')
+          .setData({'flower': FieldValue.delete()});
+      final document = await firestore.document('root/foo').get();
       expect(document.data.isEmpty, equals(true));
     });
 
@@ -489,5 +491,58 @@ void main() {
     final savedFoo = docs.documents.first;
     final nameMap = savedFoo['name'] as Map<String, dynamic>;
     expect(nameMap['firstName'], 'Survivor');
+  });
+
+  test('MockFirestoreInstance.document with a valid path', () async {
+    final firestore = MockFirestoreInstance();
+    final documentReference = firestore.document('users/1234');
+    expect(documentReference, isNotNull);
+  });
+
+  test('MockFirestoreInstance.document with a invalid path', () async {
+    final firestore = MockFirestoreInstance();
+
+    // This should fail because users (1 segments) and users/1234/friends (3 segments)
+    // are a reference to a subcollection, not a document.
+    // In real Firestore, the behavior of this error depends on the platforms;
+    // in iOS, it's NSInternalInconsistencyException that would terminate
+    // the app. This library imitates it with assert.
+    // https://github.com/atn832/cloud_firestore_mocks/issues/30
+    try {
+      firestore.document('users');
+      fail('firestore.document should detect invalid segment length');
+    } on AssertionError catch (_) {
+      // pass
+    }
+
+    // subcollection
+    try {
+      firestore.document('users/1234/friends');
+      fail(
+          'firestore.document should detect invalid segment length for subcollection');
+    } on AssertionError catch (_) {
+      // pass
+    }
+  });
+
+  test('MockFirestoreInstance.collection with a invalid path', () async {
+    final firestore = MockFirestoreInstance();
+
+    // This should fail because users/1234 (2 segments) is a reference to a
+    // document, not a collection.
+    try {
+      firestore.collection('users/1234');
+      fail('firestore.document should detect invalid segment length');
+    } on AssertionError catch (_) {
+      // pass
+    }
+
+    try {
+      firestore.collection('users/1234/friends/567');
+      fail(
+          'firestore.document should detect invalid segment length for subcollection');
+    } on AssertionError catch (_) {
+      // pass
+    }
   });
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -508,20 +508,12 @@ void main() {
     // in iOS, it's NSInternalInconsistencyException that would terminate
     // the app. This library imitates it with assert.
     // https://github.com/atn832/cloud_firestore_mocks/issues/30
-    try {
-      firestore.document('users');
-      fail('firestore.document should fail upon invalid segment length');
-    } on AssertionError catch (_) {
-      // pass
-    }
+    expect(() => firestore.document('users'),
+        throwsA(isA<AssertionError>()));
 
     // subcollection
-    try {
-      firestore.document('users/1234/friends');
-      fail('firestore.document should fail upon invalid segment length');
-    } on AssertionError catch (_) {
-      // pass
-    }
+    expect(() => firestore.document('users/1234/friends'),
+        throwsA(isA<AssertionError>()));
   });
 
   test('MockFirestoreInstance.collection with a invalid path', () async {


### PR DESCRIPTION
Fixes #30 

This is to simulate the error in the issues. Firebase users encounter similar errors https://stackoverflow.com/questions/46639058/firebase-cloud-firestore-invalid-collection-reference-collection-references-m . Detecting such mistake in widget tests is beneficial to Firebase users' developer experience.

