### PR TITLE
MockQuery to defer query execution until getDocuments

### DIFF
--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -17,6 +17,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
   final Map<String, dynamic> root;
   final Map<String, dynamic> snapshotStreamControllerRoot;
   final MockFirestoreInstance _firestore;
+
   /// Path from the root to this collection. For example "users/USER0004/friends"
   final String _path;
 
@@ -33,25 +34,23 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
 
   MockCollectionReference(
       this._firestore, this._path, this.root, this.snapshotStreamControllerRoot)
-      : super(
-            _firestore,
-            root.entries
-                .map((entry) {
-                  MockDocumentReference documentReference = _documentReference(
-                      _firestore,
-                      _path,
-                      entry.key,
-                      root,
-                      snapshotStreamControllerRoot);
-                  return MockDocumentSnapshot(
-                      documentReference,
-                      entry.key,
-                      entry.value,
-                      _firestore.hasSavedDocument(documentReference.path));
-                })
-                .where((snapshot) =>
-                    _firestore.hasSavedDocument(snapshot.reference.path))
-                .toList());
+      : super();
+
+  @override
+  Future<QuerySnapshot> getDocuments(
+      {Source source = Source.serverAndCache}) async {
+    final documents = root.entries
+        .map((entry) {
+          MockDocumentReference documentReference = _documentReference(
+              _firestore, _path, entry.key, root, snapshotStreamControllerRoot);
+          return MockDocumentSnapshot(documentReference, entry.key, entry.value,
+              _firestore.hasSavedDocument(documentReference.path));
+        })
+        .where(
+            (snapshot) => _firestore.hasSavedDocument(snapshot.reference.path))
+        .toList();
+    return MockSnapshot(documents);
+  }
 
   static final Random _random = Random();
   static final String _autoIdCharacters =

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -1,45 +1,63 @@
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:mockito/mockito.dart';
 
 import 'mock_snapshot.dart';
 
-class MockQuery extends Mock implements Query {
-  List<DocumentSnapshot> documents;
-  final MockFirestoreInstance _firestore;
+typedef List<DocumentSnapshot> _QueryOperation(List<DocumentSnapshot> input);
 
-  MockQuery(this._firestore, this.documents);
+class MockQuery extends Mock implements Query {
+  /// Previous query in a Firestore query chain. Null if this instance is a
+  /// collection reference. A query chain always starts with a collection
+  /// reference, which does not have a previous query.
+  final Query _parentQuery;
+
+  /// Operation to perform in this query, such as "where", "limit", and
+  /// "orderBy". Null if this is a collection reference.
+  final _QueryOperation _operation;
+
+  MockQuery([this._parentQuery, this._operation]);
 
   // ignore: unused_field
   final QueryPlatform _delegate = null;
 
   @override
-  Future<QuerySnapshot> getDocuments({Source source = Source.serverAndCache}) {
-    final savedDocuments = documents.where((snapshot) => _firestore.hasSavedDocument(snapshot.reference.path)).toList();
-    return Future.value(MockSnapshot(savedDocuments));
+  Future<QuerySnapshot> getDocuments(
+      {Source source = Source.serverAndCache}) async {
+    assert(_parentQuery != null,
+        'Parent query must be non-null except collection references');
+    assert(_operation != null,
+        'Operation must be non-null except collection references');
+    final parentQueryResult = await _parentQuery.getDocuments(source: source);
+    final documents = _operation(parentQueryResult.documents);
+    return MockSnapshot(documents);
   }
 
   @override
   Stream<QuerySnapshot> snapshots({bool includeMetadataChanges = false}) {
-    return Stream.fromIterable([MockSnapshot(documents)]);
+    return Stream.fromFuture(getDocuments());
   }
 
+  @override
   Query orderBy(dynamic field, {bool descending = false}) {
-    final sortedList = List.of(documents);
-    sortedList.sort((d1, d2) {
-      final value1 = d1.data[field] as Comparable;
-      final value2 = d2.data[field];
-      final compare = value1.compareTo(value2);
-      return descending ? -compare : compare;
+    return MockQuery(this, (documents) {
+      final sortedList = List.of(documents);
+      sortedList.sort((d1, d2) {
+        final value1 = d1.data[field] as Comparable;
+        final value2 = d2.data[field];
+        final compare = value1.compareTo(value2);
+        return descending ? -compare : compare;
+      });
+      return sortedList;
     });
-    return MockQuery(_firestore, sortedList);
   }
 
+  @override
   Query limit(int length) {
-    return MockQuery(_firestore, documents.sublist(0, min(documents.length, length)));
+    return MockQuery(this,
+        (documents) => documents.sublist(0, min(documents.length, length)));
   }
 
   @override
@@ -53,19 +71,19 @@ class MockQuery extends Mock implements Query {
       List<dynamic> arrayContainsAny,
       List<dynamic> whereIn,
       bool isNull}) {
-    final matchingDocuments = this.documents.where((document) {
-      return _valueMatchesQuery(document[field],
-          isEqualTo: isEqualTo,
-          isLessThan: isLessThan,
-          isLessThanOrEqualTo: isLessThanOrEqualTo,
-          isGreaterThan: isGreaterThan,
-          isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
-          arrayContains: arrayContains,
-          arrayContainsAny: arrayContainsAny,
-          whereIn: whereIn,
-          isNull: isNull);
-    }).toList();
-    return MockQuery(_firestore, matchingDocuments);
+    _QueryOperation operation = (documents) => documents
+        .where((document) => _valueMatchesQuery(document[field],
+            isEqualTo: isEqualTo,
+            isLessThan: isLessThan,
+            isLessThanOrEqualTo: isLessThanOrEqualTo,
+            isGreaterThan: isGreaterThan,
+            isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+            arrayContains: arrayContains,
+            arrayContainsAny: arrayContainsAny,
+            whereIn: whereIn,
+            isNull: isNull))
+        .toList();
+    return MockQuery(this, operation);
   }
 
   bool _valueMatchesQuery(dynamic value,

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -227,7 +227,7 @@ void main() {
     final instance = MockFirestoreInstance();
 
     final collectionReference = instance.collection('users/1234/friends');
-    final query1 = collectionReference.where('username', isGreaterThan: 'A');
+    final query1 = collectionReference.where('username', isGreaterThan: 'B');
     final query2 = query1.orderBy('username');
     final query3 = query2.limit(1);
 
@@ -235,18 +235,19 @@ void main() {
     expect(snapshotBeforeAdd.documents, isEmpty);
 
     await collectionReference.add({
-      'username': 'Brian',
-    });
-    await collectionReference.add({
       'username': 'Alex',
     });
     await collectionReference.add({
       'username': 'Charlie',
     });
+    await collectionReference.add({
+      'username': 'Brian',
+    });
 
     final snapshotAfterAdd = await query3.getDocuments();
     expect(snapshotAfterAdd.documents, hasLength(1)); // limit 1
-    // 'Alex' comes 'Brian' or 'Charlie'
-    expect(snapshotAfterAdd.documents.first.data['username'], 'Alex');
+    // Alex is filtered out by 'where' query.
+    // 'Brian' comes before 'Charlie'
+    expect(snapshotAfterAdd.documents.first.data['username'], 'Brian');
   });
 }


### PR DESCRIPTION
Fixes #31 

MockQuery should not hold the query results; otherwise it may return stale data.

In my use case, my class hold a collection reference (a final field) during the whole lifetime of my app. The class adds and retrieves documents from the Firestore collection through the the same reference.