### PR TITLE
add support for arrayContains in where

### DIFF
--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -122,6 +122,12 @@ class MockQuery extends Mock implements Query {
         isLessThanOrEqualTo = Timestamp.fromDate(isLessThanOrEqualTo);
       }
       return fieldValue.compareTo(isLessThanOrEqualTo) <= 0;
+    } else if (arrayContains != null) {
+      if (value is Iterable) {
+        return value.contains(arrayContains);
+      } else {
+        return false;
+      }
     }
     throw "Unsupported";
   }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -155,6 +155,39 @@ void main() {
     expect(snapshot.documents.length, equals(2));
     expect(snapshot.documents.first['tag'], equals('mostrecent'));
   });
+
+  test('arrayContains', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('posts').add({
+      'name': 'Post #1',
+      'tags': ['mostrecent', 'interesting'],
+    });
+    await instance.collection('posts').add({
+      'name': 'Post #2',
+      'tags': ['mostrecent'],
+    });
+    await instance.collection('posts').add({
+      'name': 'Post #3',
+      'tags': ['mostrecent'],
+    });
+    await instance.collection('posts').add({
+      'name': 'Post #4',
+      'tags': ['mostrecent', 'interesting'],
+    });
+    instance
+        .collection('posts')
+        .where('tags', arrayContains: 'interesting')
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+      expect(snapshot.documents.length, equals(2));
+
+      /// verify the matching documents were returned
+      snapshot.documents.forEach((returnedDocument) {
+        expect(returnedDocument.data['tags'], contains('interesting'));
+      });
+    }));
+  });
+
   test('Collection.getDocuments', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').add({


### PR DESCRIPTION
Adds support for `arrayContains`. This assumes that the correct behavior for using arrayContains on a field that is not of an array type is to not match any documents. This appears to be how it works in the JS SDK at least but I could not find a reference that explicitly states that. 