### PR TITLE
Adds driver test for arrayContains

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See more examples at [cloud_firestore_mocks/example/test/widget_test.dart](https
 - Batch writes and `runTransaction`.
 - Query documents with `collection.snapshots` or `query.getDocuments`.
 - Queries:
-  - Filter results with `query.where`. The library supports `equals`, `isGreaterThan`, `isGreaterThanOrEqualTo`, `isLessThan`, and `isLessThanOrEqualTo`.
+  - Filter results with `query.where`. The library supports `equals`, `isGreaterThan`, `isGreaterThanOrEqualTo`, `isLessThan`,`isLessThanOrEqualTo` and `arrayContains`.
   - Sort results with `query.orderBy`.
   - Limit results with `query.limit`.
 - `ValueField`:

--- a/test_driver/cloud_firestore_behaviors.dart
+++ b/test_driver/cloud_firestore_behaviors.dart
@@ -502,4 +502,39 @@ void main() {
       expect(result['Blob'], Blob(utf8.encode('bytes')));
     });
   });
+
+  ftest('Where: array-contains', (firestore) async {
+    await firestore
+        .collection('posts')
+        .add({'name': 'Document Missing Queried Field'});
+    await firestore
+        .collection('posts')
+        .add({'name': 'Non-Array Field Type', 'tags': 'interesting'});
+    await firestore.collection('posts').add({
+      'name': 'Post #1',
+      'tags': ['mostrecent', 'interesting'],
+    });
+    await firestore.collection('posts').add({
+      'name': 'Post #2',
+      'tags': ['mostrecent'],
+    });
+    await firestore.collection('posts').add({
+      'name': 'Post #3',
+      'tags': ['mostrecent'],
+    });
+    await firestore.collection('posts').add({
+      'name': 'Post #4',
+      'tags': ['mostrecent', 'interesting'],
+    });
+    final result = await firestore
+        .collection('posts')
+        .where('tags', arrayContains: 'interesting')
+        .getDocuments();
+    expect(result.documents.length, equals(2));
+
+    // verify the matching documents were returned
+    result.documents.forEach((returnedDocument) {
+      expect(returnedDocument.data['tags'], contains('interesting'));
+    });
+  });
 }


### PR DESCRIPTION
Fixes #71 

I am a little unclear on how to run this test on the android emulator to make sure its working. The [readme](https://github.com/atn832/cloud_firestore_mocks/tree/master/test_driver#run-driver-test) says to run in the example folder but the `cloud_firestore_behaviors.dart` file doesn't exist there. 