### PR TITLE
Add support for whereIn query

### DIFF
--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -152,6 +152,11 @@ class MockQuery extends Mock implements Query {
           'arrayContainsAny cannot contain more than 10 comparison values',
         );
       }
+      if (whereIn != null) {
+        throw FormatException(
+          'arrayContainsAny cannot be combined with whereIn',
+        );
+      }
       if (value is Iterable) {
         var valueSet = Set.from(value);
         for (var elem in arrayContainsAny) {
@@ -163,6 +168,21 @@ class MockQuery extends Mock implements Query {
       } else {
         return false;
       }
+    } else if (whereIn != null) {
+      if (whereIn.length > 10) {
+        throw ArgumentError(
+          'whereIn cannot contain more than 10 comparison values',
+        );
+      }
+      if (arrayContainsAny != null) {
+        throw FormatException(
+          'whereIn cannot be combined with arrayContainsAny',
+        );
+      }
+      if (whereIn.contains(value)) {
+        return true;
+      }
+      return false;
     }
     throw "Unsupported";
   }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -236,6 +236,60 @@ void main() {
         }));
   });
 
+  test('whereIn', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('contestants').add({
+      'name': 'Alice',
+      'country': 'USA',
+      'skills': ['cycling', 'running']
+    });
+    await instance.collection('contestants').add({
+      'name': 'Bob',
+      'country': 'Japan',
+      'skills': ['gymnastics', 'swimming']
+    });
+    await instance.collection('contestants').add({
+      'name': 'Celina',
+      'country': 'India',
+      'skills': ['swimming', 'running']
+    });
+    instance
+        .collection('contestants')
+        .where('country', whereIn: ['Japan', 'India'])
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+          expect(snapshot.documents.length, equals(2));
+        }));
+    instance
+        .collection('contestants')
+        .where('country', whereIn: ['USA'])
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+          expect(snapshot.documents.length, equals(1));
+        }));
+    instance
+        .collection('contestants')
+        .where(
+          'country',
+          whereIn: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L'],
+        )
+        .snapshots()
+        .listen(null, onError: expectAsync1((error) {
+          expect(error, isA<ArgumentError>());
+        }));
+    instance
+        .collection('contestants')
+        .where(
+          'country',
+          whereIn: ['India'],
+          arrayContainsAny: ['USA'],
+        )
+        .snapshots()
+        .listen(null, onError: expectAsync1((error) {
+          expect(error, isFormatException);
+        }));
+  });
+
   test('Collection.getDocuments', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').add({


### PR DESCRIPTION
Fixes #67 

This change will allow to use `whereIn` operator with query.where

See official Firestore documentation for more details:
https://firebase.google.com/docs/firestore/query-data/queries#in_and_array-contains-any