### PR TITLE
Always do a deep copy of the data when creating a MockDocumentSnapshot.

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -117,7 +117,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
   @override
   Future<DocumentSnapshot> get({Source source = Source.serverAndCache}) {
     return Future.value(
-        MockDocumentSnapshot(this, _documentId, deepCopy(root), _exists()));
+        MockDocumentSnapshot(this, _documentId, root, _exists()));
   }
 
   bool _exists() {

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_mocks/src/mock_document_reference.dart';
+import 'package:cloud_firestore_mocks/src/util.dart';
 import 'package:mockito/mockito.dart';
 
 class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
@@ -8,8 +9,9 @@ class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
   final bool _exists;
   final MockDocumentReference _reference;
 
-  MockDocumentSnapshot(
-      this._reference, this._documentId, this._document, this._exists);
+  MockDocumentSnapshot(this._reference, this._documentId,
+      Map<String, dynamic> document, this._exists)
+      : _document = deepCopy(document);
 
   @override
   String get documentID => _documentId;


### PR DESCRIPTION
Fixes atn832/cloud_firestore_mocks#83