### PR TITLE
Mock Document Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ ios/Runner.xcworkspace/xcuserdata/
 android/.gradle/
 
 *.log
+.idea

--- a/lib/src/mock_document_change.dart
+++ b/lib/src/mock_document_change.dart
@@ -1,0 +1,14 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:mockito/mockito.dart';
+
+class MockDocumentChange extends Mock implements DocumentChange {
+  final DocumentSnapshot _document;
+
+  MockDocumentChange(this._document);
+
+  @override
+  DocumentChangeType get type => DocumentChangeType.added;
+
+  @override
+  DocumentSnapshot get document => _document;
+}

--- a/lib/src/mock_snapshot.dart
+++ b/lib/src/mock_snapshot.dart
@@ -1,11 +1,20 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore_mocks/src/mock_document_change.dart';
 import 'package:mockito/mockito.dart';
 
 class MockSnapshot extends Mock implements QuerySnapshot {
-  List<DocumentSnapshot> _documents;
+  final List<DocumentSnapshot> _documents;
 
-  MockSnapshot(this._documents);
+  final List<DocumentChange> _documentChanges = <DocumentChange>[];
+
+  MockSnapshot(this._documents) {
+    _documents.forEach((document) {
+      _documentChanges.add(MockDocumentChange(document));
+    });
+  }
 
   @override
   List<DocumentSnapshot> get documents => _documents;
+
+  List<DocumentChange> get documentChanges => _documentChanges;
 }

--- a/lib/src/mock_snapshot.dart
+++ b/lib/src/mock_snapshot.dart
@@ -16,5 +16,6 @@ class MockSnapshot extends Mock implements QuerySnapshot {
   @override
   List<DocumentSnapshot> get documents => _documents;
 
+  @override
   List<DocumentChange> get documentChanges => _documentChanges;
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -134,6 +134,16 @@ void main() {
           'name': 'Bob',
         })));
   });
+  test('Snapshots returns a Stream of Snapshot changes', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('users').document(uid).setData({
+      'name': 'Bob',
+    });
+    instance.collection('users').snapshots().listen(expectAsync1((snap) {
+      expect(snap.documentChanges.length, 1);
+      expect(snap.documentChanges[0].type, DocumentChangeType.added);
+    }));
+  });
   test('Snapshots sets exists property to false if the document does not exist',
       () async {
     final instance = MockFirestoreInstance();
@@ -463,17 +473,18 @@ void main() {
 
     test('FieldValue in nested objects', () async {
       final firestore = MockFirestoreInstance();
-      final docRef = firestore.collection('MyCollection').document('MyDocument');
+      final docRef =
+          firestore.collection('MyCollection').document('MyDocument');
       final batch = firestore.batch();
 
       batch.setData(
-        docRef,
-        {
-          'testme': FieldValue.increment(1),
-          'updated': FieldValue.serverTimestamp(),
-          'Nested': {'testnestedfield': FieldValue.increment(1)}
-        },
-        merge: true);
+          docRef,
+          {
+            'testme': FieldValue.increment(1),
+            'updated': FieldValue.serverTimestamp(),
+            'Nested': {'testnestedfield': FieldValue.increment(1)}
+          },
+          merge: true);
       await batch.commit();
 
       final myDocs = await firestore.collection('MyCollection').getDocuments();


### PR DESCRIPTION
Expand `MockSnapshot` to support the `documentChanges` API.

This adds support for added documents only, as `fireSnapshotUpdate` won't fire for other events.

Regards