### PR TITLE
Correctly setup `MockQuery.snapshots()` to broadcast data to 'already listening' streams.

### DIFF
--- a/example/android/local.properties
+++ b/example/android/local.properties
@@ -1,3 +1,3 @@
-sdk.dir=/Users/anhtuan/Library/Android/sdk
-flutter.sdk=/Users/anhtuan/flutter
+sdk.dir=/Users/gen/Library/Android/sdk
+flutter.sdk=/Users/gen/Apps/flutter/flutter
 flutter.buildMode=debug

--- a/example/android/local.properties
+++ b/example/android/local.properties
@@ -1,3 +1,3 @@
-sdk.dir=/Users/gen/Library/Android/sdk
-flutter.sdk=/Users/gen/Apps/flutter/flutter
+sdk.dir=/Users/anhtuan/Library/Android/sdk
+flutter.sdk=/Users/anhtuan/flutter
 flutter.buildMode=debug

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -113,7 +113,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
     await documentReference.updateData(data);
 
     _firestore.saveDocument(documentReference.path);
-
+    QuerySnapshotStreamManager().fireSnapshotUpdate();
     fireSnapshotUpdate();
     return documentReference;
   }

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -113,7 +113,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
     await documentReference.updateData(data);
 
     _firestore.saveDocument(documentReference.path);
-    QuerySnapshotStreamManager().fireSnapshotUpdate();
+    QuerySnapshotStreamManager().fireSnapshotUpdate(path);
     fireSnapshotUpdate();
     return documentReference;
   }

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -70,7 +70,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
       _applyValues(document, key, value);
     });
     _firestore.saveDocument(path);
-    QuerySnapshotStreamManager().fireSnapshotUpdate();
+    QuerySnapshotStreamManager().fireSnapshotUpdate(path);
 
     return Future.value(null);
   }
@@ -148,7 +148,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
   Future<void> delete() {
     rootParent.remove(documentID);
     _firestore.removeSavedDocument(path);
-    QuerySnapshotStreamManager().fireSnapshotUpdate();
+    QuerySnapshotStreamManager().fireSnapshotUpdate(path);
     return Future.value();
   }
 

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -6,6 +6,7 @@ import 'cloud_firestore_mocks_base.dart';
 import 'mock_collection_reference.dart';
 import 'mock_document_snapshot.dart';
 import 'mock_field_value_platform.dart';
+import 'mock_query.dart';
 import 'util.dart';
 
 class MockDocumentReference extends Mock implements DocumentReference {
@@ -69,6 +70,8 @@ class MockDocumentReference extends Mock implements DocumentReference {
       _applyValues(document, key, value);
     });
     _firestore.saveDocument(path);
+    QuerySnapshotStreamManager().fireSnapshotUpdate();
+
     return Future.value(null);
   }
 
@@ -145,6 +148,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
   Future<void> delete() {
     rootParent.remove(documentID);
     _firestore.removeSavedDocument(path);
+    QuerySnapshotStreamManager().fireSnapshotUpdate();
     return Future.value();
   }
 

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -236,8 +236,10 @@ class QuerySnapshotStreamManager {
       {};
 
   void clear() {
-    for (var maps in _streamCache.values) {
-      maps.forEach((_, value) => value.close());
+    for (final queryToStreamController in _streamCache.values) {
+      for (final streamController in queryToStreamController.values) {
+        streamController.close();
+      }
     }
     _streamCache.clear();
   }

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -47,10 +47,9 @@ class MockQuery extends Mock implements Query {
   @override
   Stream<QuerySnapshot> snapshots({bool includeMetadataChanges = false}) {
     QuerySnapshotStreamManager().register(this);
-    return QuerySnapshotStreamManager()
-        .getStreamController(this)
-        .stream
-        .distinct((prev, next) {
+    final controller = QuerySnapshotStreamManager().getStreamController(this);
+    controller.addStream(Stream.fromFuture(getDocuments()));
+    return controller.stream.distinct((prev, next) {
       if (prev.documents.length != next.documents.length) {
         return false;
       }

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -286,7 +286,6 @@ class QuerySnapshotStreamManager {
     if (pathCache == null) {
       return;
     }
-    // print('fireSnapshotUpdate cache (for $path) length ${pathCache.length}');
     final queriesWithNoListener = <Query>[];
     for (final query in pathCache.keys) {
       if (pathCache[query].hasListener) {

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -42,7 +42,7 @@ class MockQuery extends Mock implements Query {
     return MockSnapshot(documents);
   }
 
-  final _unOrdDeepEq = const DeepCollectionEquality.unordered();
+  final _unorderedDeepEquality = const DeepCollectionEquality.unordered();
 
   @override
   Stream<QuerySnapshot> snapshots({bool includeMetadataChanges = false}) {
@@ -59,7 +59,7 @@ class MockQuery extends Mock implements Query {
           return false;
         }
 
-        if (!_unOrdDeepEq.equals(
+        if (!_unorderedDeepEquality.equals(
             prev.documents[i].data, next.documents[i].data)) {
           return false;
         }
@@ -285,15 +285,15 @@ class QuerySnapshotStreamManager {
       return;
     }
     // print('fireSnapshotUpdate cache (for $path) length ${pathCache.length}');
-    final noListnerQueries = <Query>[];
+    final queriesWithNoListener = <Query>[];
     for (final query in pathCache.keys) {
       if (pathCache[query].hasListener) {
         query.getDocuments().then(pathCache[query].add);
       } else {
-        noListnerQueries.add(query);
+        queriesWithNoListener.add(query);
       }
     }
     // cleanup cached stream controller which has no lister.
-    noListnerQueries.forEach(pathCache.remove);
+    queriesWithNoListener.forEach(pathCache.remove);
   }
 }

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -49,23 +49,26 @@ class MockQuery extends Mock implements Query {
     QuerySnapshotStreamManager().register(this);
     final controller = QuerySnapshotStreamManager().getStreamController(this);
     controller.addStream(Stream.fromFuture(getDocuments()));
-    return controller.stream.distinct((prev, next) {
-      if (prev.documents.length != next.documents.length) {
+    return controller.stream.distinct(_snapshotEquals);
+  }
+
+  bool _snapshotEquals(snapshot1, snapshot2) {
+    if (snapshot1.documents.length != snapshot2.documents.length) {
+      return false;
+    }
+
+    for (var i = 0; i < snapshot1.documents.length; i++) {
+      if (snapshot1.documents[i].documentID !=
+          snapshot2.documents[i].documentID) {
         return false;
       }
 
-      for (var i = 0; i < prev.documents.length; i++) {
-        if (prev.documents[i].documentID != next.documents[i].documentID) {
-          return false;
-        }
-
-        if (!_unorderedDeepEquality.equals(
-            prev.documents[i].data, next.documents[i].data)) {
-          return false;
-        }
+      if (!_unorderedDeepEquality.equals(
+          snapshot1.documents[i].data, snapshot2.documents[i].data)) {
+        return false;
       }
-      return true;
-    });
+    }
+    return true;
   }
 
   @override

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -242,16 +242,16 @@ class QuerySnapshotStreamManager {
     _streamCache.clear();
   }
 
-  String _retribeParentPath(MockQuery query) {
+  String _retriveParentPath(MockQuery query) {
     if (query._parentQuery is CollectionReference) {
       return (query._parentQuery as CollectionReference).path;
     } else {
-      return _retribeParentPath(query._parentQuery);
+      return _retriveParentPath(query._parentQuery);
     }
   }
 
   void register(Query query) {
-    final path = _retribeParentPath(query);
+    final path = _retriveParentPath(query);
     if (_streamCache.containsKey(path)) {
       _streamCache[path].putIfAbsent(
           query, () => StreamController<QuerySnapshot>.broadcast());
@@ -261,7 +261,7 @@ class QuerySnapshotStreamManager {
   }
 
   void unregister(Query query) {
-    final path = _retribeParentPath(query);
+    final path = _retriveParentPath(query);
     final pathCache = _streamCache[path];
     if (pathCache == null) {
       return;
@@ -271,7 +271,7 @@ class QuerySnapshotStreamManager {
   }
 
   StreamController<QuerySnapshot> getStreamController(Query query) {
-    final path = _retribeParentPath(query);
+    final path = _retriveParentPath(query);
     final pathCache = _streamCache[path];
     if (pathCache == null) {
       return null;

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -286,15 +286,10 @@ class QuerySnapshotStreamManager {
     if (pathCache == null) {
       return;
     }
-    final queriesWithNoListener = <Query>[];
     for (final query in pathCache.keys) {
       if (pathCache[query].hasListener) {
         query.getDocuments().then(pathCache[query].add);
-      } else {
-        queriesWithNoListener.add(query);
       }
     }
-    // cleanup cached stream controller which has no lister.
-    queriesWithNoListener.forEach(pathCache.remove);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: http://blog.wafrat.com
 repository: https://github.com/atn832/cloud_firestore_mocks
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   cloud_firestore_platform_interface: ^1.0.0
   plugin_platform_interface: ^1.0.1
   mockito: ^4.1.0
+  quiver: ^2.1.3
 
 dev_dependencies:
   flutter_test:

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -576,20 +576,20 @@ void main() {
       }
     ];
 
-    final ascendingContnts = [
+    final ascContnts = [
       ['hello!'],
       ['hello!', 'bonjour!'],
       ['hola!', 'hello!', 'bonjour!'],
     ];
 
-    final descendingContnts = [
+    final descContnts = [
       ['hello!'],
       ['bonjour!', 'hello!'],
       ['bonjour!', 'hello!', 'hola!'],
     ];
 
     final instance = MockFirestoreInstance();
-    var ascendingCalled = 0;
+    var ascCalled = 0;
     instance
         .collection('messages')
         .orderBy('receivedAt')
@@ -597,23 +597,23 @@ void main() {
         .listen(expectAsync1((snapshot) {
           final docs = snapshot.documents;
           try {
-            if (ascendingCalled == 0) {
+            if (ascCalled == 0) {
               expect(docs, isEmpty);
               return;
             } else {
-              expect(docs.length, ascendingContnts[ascendingCalled - 1].length);
+              expect(docs.length, ascContnts[ascCalled - 1].length);
             }
             for (var i = 0; i < docs.length; i++) {
               expect(
                 docs[i].data['content'],
-                equals(ascendingContnts[ascendingCalled - 1][i]),
+                equals(ascContnts[ascCalled - 1][i]),
               );
             }
           } finally {
-            ascendingCalled++;
+            ascCalled++;
           }
         }, count: testData.length + 1));
-    var descendingCalled = 0;
+    var descCalled = 0;
     instance
         .collection('messages')
         .orderBy('receivedAt', descending: true)
@@ -621,21 +621,20 @@ void main() {
         .listen(expectAsync1((snapshot) {
           final docs = snapshot.documents;
           try {
-            if (descendingCalled == 0) {
+            if (descCalled == 0) {
               expect(docs, isEmpty);
               return;
             } else {
-              expect(
-                  docs.length, descendingContnts[descendingCalled - 1].length);
+              expect(docs.length, descContnts[descCalled - 1].length);
             }
             for (var i = 0; i < docs.length; i++) {
               expect(
                 docs[i].data['content'],
-                equals(descendingContnts[descendingCalled - 1][i]),
+                equals(descContnts[descCalled - 1][i]),
               );
             }
           } finally {
-            descendingCalled++;
+            descCalled++;
           }
         }, count: testData.length + 1));
 
@@ -665,7 +664,7 @@ void main() {
       },
     ];
 
-    final unarchivedAscendingContents = [
+    final unarchivedAscContents = [
       ['hello!'],
       ['hola!', 'hello!'],
       ['hola!', 'hello!', 'Ciao!'],
@@ -685,19 +684,18 @@ void main() {
               expect(docs, isEmpty);
               return;
             } else {
-              expect(
-                  docs.length, unarchivedAscendingContents[called - 1].length);
+              expect(docs.length, unarchivedAscContents[called - 1].length);
             }
             for (var i = 0; i < docs.length; i++) {
               expect(
                 docs[i].data['content'],
-                equals(unarchivedAscendingContents[called - 1][i]),
+                equals(unarchivedAscContents[called - 1][i]),
               );
             }
           } finally {
             called++;
           }
-        }, count: unarchivedAscendingContents.length + 1));
+        }, count: unarchivedAscContents.length + 1));
 
     await instance.collection('messages').add(testData[0]);
     await instance.collection('messages').add(testData[1]);

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -514,7 +514,7 @@ void main() {
         .snapshots()
         .listen(expectAsync1((snapshot) {
           expect(snapshot.documents.length, inInclusiveRange(0, 2));
-          for (var d in snapshot.documents) {
+          for (final d in snapshot.documents) {
             expect(d.data['archived'], isFalse);
           }
         }, count: 3)); // initial [], when add 'hello!' and when add 'hola!'.
@@ -525,7 +525,7 @@ void main() {
         .snapshots()
         .listen(expectAsync1((snapshot) {
           expect(snapshot.documents.length, inInclusiveRange(0, 1));
-          for (var d in snapshot.documents) {
+          for (final d in snapshot.documents) {
             expect(d.data['archived'], isTrue);
           }
         }, count: 2)); // initial [], when add 'hello!' and when add 'hola!'.
@@ -555,7 +555,7 @@ void main() {
         .snapshots()
         .listen(expectAsync1((snapshot) {
       expect(snapshot.documents.length, equals(2));
-      for (var d in snapshot.documents) {
+      for (final d in snapshot.documents) {
         expect(d.data['archived'], isFalse);
       }
     }));

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -513,20 +513,22 @@ void main() {
         .where('archived', isEqualTo: false)
         .snapshots()
         .listen(expectAsync1((snapshot) {
+          expect(snapshot.documents.length, inInclusiveRange(0, 2));
           for (var d in snapshot.documents) {
             expect(d.data['archived'], isFalse);
           }
-        }, count: 2)); // when add 'hello!' and when add 'hola!'.
+        }, count: 3)); // initial [], when add 'hello!' and when add 'hola!'.
 
     instance
         .collection('messages')
         .where('archived', isEqualTo: true)
         .snapshots()
         .listen(expectAsync1((snapshot) {
+          expect(snapshot.documents.length, inInclusiveRange(0, 1));
           for (var d in snapshot.documents) {
             expect(d.data['archived'], isTrue);
           }
-        }, count: 1)); // when add 'hello!' and when add 'hola!'.
+        }, count: 2)); // initial [], when add 'hello!' and when add 'hola!'.
 
     // this should be received.
     await instance.collection('messages').add({
@@ -549,15 +551,16 @@ void main() {
     });
     print('added hola!');
 
+    // check new stream will receive the latest data.
     instance
         .collection('messages')
         .where('archived', isEqualTo: false)
         .snapshots()
-        .listen((event) {
-      event.documents.forEach((element) {
-        fail(
-            'This stream should now called because this started to listen after adding data.');
-      });
-    });
+        .listen(expectAsync1((snapshot) {
+      expect(snapshot.documents.length, equals(2));
+      for (var d in snapshot.documents) {
+        expect(d.data['archived'], isFalse);
+      }
+    }));
   });
 }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -569,12 +569,10 @@ void main() {
       {
         'content': 'bonjour!',
         'receivedAt': now.add(const Duration(seconds: 1)),
-        'archived': true,
       },
       {
         'content': 'hola!',
         'receivedAt': now.subtract(const Duration(seconds: 1)),
-        'archived': false,
       }
     ];
 
@@ -597,17 +595,17 @@ void main() {
         .orderBy('receivedAt')
         .snapshots()
         .listen(expectAsync1((snapshot) {
+          final docs = snapshot.documents;
           try {
             if (ascendingCalled == 0) {
-              expect(snapshot.documents, isEmpty);
+              expect(docs, isEmpty);
               return;
             } else {
-              expect(snapshot.documents.length,
-                  inInclusiveRange(1, testData.length));
+              expect(docs.length, ascendingContnts[ascendingCalled - 1].length);
             }
-            for (var i = 0; i < snapshot.documents.length; i++) {
+            for (var i = 0; i < docs.length; i++) {
               expect(
-                snapshot.documents[i].data['content'],
+                docs[i].data['content'],
                 equals(ascendingContnts[ascendingCalled - 1][i]),
               );
             }
@@ -621,17 +619,18 @@ void main() {
         .orderBy('receivedAt', descending: true)
         .snapshots()
         .listen(expectAsync1((snapshot) {
+          final docs = snapshot.documents;
           try {
             if (descendingCalled == 0) {
-              expect(snapshot.documents, isEmpty);
+              expect(docs, isEmpty);
               return;
             } else {
-              expect(snapshot.documents.length,
-                  inInclusiveRange(0, testData.length));
-            }
-            for (var i = 0; i < snapshot.documents.length; i++) {
               expect(
-                snapshot.documents[i].data['content'],
+                  docs.length, descendingContnts[descendingCalled - 1].length);
+            }
+            for (var i = 0; i < docs.length; i++) {
+              expect(
+                docs[i].data['content'],
                 equals(descendingContnts[descendingCalled - 1][i]),
               );
             }
@@ -680,17 +679,18 @@ void main() {
         .where('archived', isEqualTo: false)
         .snapshots()
         .listen(expectAsync1((snapshot) {
+          final docs = snapshot.documents;
           try {
             if (called == 0) {
-              expect(snapshot.documents, isEmpty);
+              expect(docs, isEmpty);
               return;
             } else {
-              expect(snapshot.documents.length,
-                  unarchivedAscendingContents[called - 1].length);
-            }
-            for (var i = 0; i < snapshot.documents.length; i++) {
               expect(
-                snapshot.documents[i].data['content'],
+                  docs.length, unarchivedAscendingContents[called - 1].length);
+            }
+            for (var i = 0; i < docs.length; i++) {
+              expect(
+                docs[i].data['content'],
                 equals(unarchivedAscendingContents[called - 1][i]),
               );
             }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -535,21 +535,18 @@ void main() {
       'content': 'hello!',
       'archived': false,
     });
-    print('added hello!');
 
     // this should not be received because of archived == true.
     await instance.collection('messages').add({
       'content': 'bonjour!',
       'archived': true,
     });
-    print('added bonjour!');
 
     // this should be received.
     await instance.collection('messages').add({
       'content': 'hola!',
       'archived': false,
     });
-    print('added hola!');
 
     // check new stream will receive the latest data.
     instance

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -158,15 +158,12 @@ void main() {
 
   test('orderBy returns documents with null fields first', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('usercourses').add({
-      'completed_at': Timestamp.fromDate(DateTime.now())
-    });
-    await instance.collection('usercourses').add({
-      'completed_at': null
-    });
+    await instance
+        .collection('usercourses')
+        .add({'completed_at': Timestamp.fromDate(DateTime.now())});
+    await instance.collection('usercourses').add({'completed_at': null});
 
-    var query = instance.collection('usercourses')
-      .orderBy('completed_at');
+    var query = instance.collection('usercourses').orderBy('completed_at');
 
     query.snapshots().listen(expectAsync1(
         (event) {

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -576,13 +576,13 @@ void main() {
       }
     ];
 
-    final ascContnts = [
+    final ascendingContents = [
       ['hello!'],
       ['hello!', 'bonjour!'],
       ['hola!', 'hello!', 'bonjour!'],
     ];
 
-    final descContnts = [
+    final descendingContents = [
       ['hello!'],
       ['bonjour!', 'hello!'],
       ['bonjour!', 'hello!', 'hola!'],
@@ -601,12 +601,12 @@ void main() {
               expect(docs, isEmpty);
               return;
             } else {
-              expect(docs.length, ascContnts[ascCalled - 1].length);
+              expect(docs.length, ascendingContents[ascCalled - 1].length);
             }
             for (var i = 0; i < docs.length; i++) {
               expect(
                 docs[i].data['content'],
-                equals(ascContnts[ascCalled - 1][i]),
+                equals(ascendingContents[ascCalled - 1][i]),
               );
             }
           } finally {
@@ -625,12 +625,12 @@ void main() {
               expect(docs, isEmpty);
               return;
             } else {
-              expect(docs.length, descContnts[descCalled - 1].length);
+              expect(docs.length, descendingContents[descCalled - 1].length);
             }
             for (var i = 0; i < docs.length; i++) {
               expect(
                 docs[i].data['content'],
-                equals(descContnts[descCalled - 1][i]),
+                equals(descendingContents[descCalled - 1][i]),
               );
             }
           } finally {

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -644,4 +644,8 @@ void main() {
     await instance.collection('messages').add(testData[1]);
     await instance.collection('messages').add(testData[2]);
   });
+
+  test('Continuous data receive via stream with orderBy and where', () async {
+    fail('TBU');
+  });
 }


### PR DESCRIPTION
# Objective
Fix the issue #111 

# Changes
- Add `QuerySnapshotStreamManager` to keep and re-fire updated data to streams for each `Query`.
- Setup `snapshots()` stream to not broadcast same data.
- Add unit test

# Tests
- [x] listening snapshot stream with `where`.
- [x] listening snapshot stream with `orderBy`.
- [x] listening snapshot stream with `where` and `orderBy`.