### PR TITLE
Bugfix/notify when update doc

### DIFF
--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -285,14 +285,17 @@ class QuerySnapshotStreamManager {
   }
 
   void fireSnapshotUpdate(String path) {
-    final pathCache = _streamCache[path];
-    if (pathCache == null) {
-      return;
-    }
-    for (final query in pathCache.keys) {
-      if (pathCache[query].hasListener) {
-        query.getDocuments().then(pathCache[query].add);
+    final exactPathCache = _streamCache[path];
+    if (exactPathCache != null) {
+      for (final query in exactPathCache.keys) {
+        if (exactPathCache[query].hasListener) {
+          query.getDocuments().then(exactPathCache[query].add);
+        }
       }
+    }
+
+    if (path.contains('/')) {
+      fireSnapshotUpdate(path.split('/').first);
     }
   }
 }

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -247,16 +247,16 @@ class QuerySnapshotStreamManager {
     _streamCache.clear();
   }
 
-  String _retriveParentPath(MockQuery query) {
+  String _retrieveParentPath(MockQuery query) {
     if (query._parentQuery is CollectionReference) {
       return (query._parentQuery as CollectionReference).path;
     } else {
-      return _retriveParentPath(query._parentQuery);
+      return _retrieveParentPath(query._parentQuery);
     }
   }
 
   void register(Query query) {
-    final path = _retriveParentPath(query);
+    final path = _retrieveParentPath(query);
     if (_streamCache.containsKey(path)) {
       _streamCache[path].putIfAbsent(
           query, () => StreamController<QuerySnapshot>.broadcast());
@@ -266,7 +266,7 @@ class QuerySnapshotStreamManager {
   }
 
   void unregister(Query query) {
-    final path = _retriveParentPath(query);
+    final path = _retrieveParentPath(query);
     final pathCache = _streamCache[path];
     if (pathCache == null) {
       return;
@@ -276,7 +276,7 @@ class QuerySnapshotStreamManager {
   }
 
   StreamController<QuerySnapshot> getStreamController(Query query) {
-    final path = _retriveParentPath(query);
+    final path = _retrieveParentPath(query);
     final pathCache = _streamCache[path];
     if (pathCache == null) {
       return null;

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -528,7 +528,7 @@ void main() {
           for (final d in snapshot.documents) {
             expect(d.data['archived'], isTrue);
           }
-        }, count: 2)); // initial [], when add 'hello!' and when add 'hola!'.
+        }, count: 2)); // initial [], when add 'bonjour!'.
 
     // this should be received.
     await instance.collection('messages').add({

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -668,6 +668,8 @@ void main() {
       ['hello!'],
       ['hola!', 'hello!'],
       ['hola!', 'hello!', 'Ciao!'],
+      ['hola!', 'hello!'],
+      ['hello!'],
     ];
 
     final instance = MockFirestoreInstance();
@@ -697,9 +699,19 @@ void main() {
           }
         }, count: unarchivedAscContents.length + 1));
 
+    // add data
     await instance.collection('messages').add(testData[0]);
     await instance.collection('messages').add(testData[1]);
-    await instance.collection('messages').add(testData[2]);
-    await instance.collection('messages').add(testData[3]);
+    final holaDoc = await instance.collection('messages').add(testData[2]);
+    final chaoDoc = await instance.collection('messages').add(testData[3]);
+    // update data
+    await instance
+        .collection('messages')
+        .document(chaoDoc.documentID)
+        .updateData({
+      'archived': true,
+    });
+    // delete data
+    await instance.collection('messages').document(holaDoc.documentID).delete();
   });
 }


### PR DESCRIPTION
# Objective
For https://github.com/atn832/cloud_firestore_mocks/issues/111, notify updated/deleted data results to existing stream which is listening parent collection.

# Changes
- update unit test logic to check updating/deleting data.
- update `fireSnapshotUpdate()` method to notify date to "parent path" stream.