### PR TITLE
Add FieldPath.documentId support in MockQuery.where & MockQuery.orderBy

### DIFF
--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -139,18 +139,24 @@ class MockQuery extends Mock implements Query {
       List<dynamic> arrayContainsAny,
       List<dynamic> whereIn,
       bool isNull}) {
-    _QueryOperation operation = (documents) => documents
-        .where((document) => _valueMatchesQuery(document[field],
-            isEqualTo: isEqualTo,
-            isLessThan: isLessThan,
-            isLessThanOrEqualTo: isLessThanOrEqualTo,
-            isGreaterThan: isGreaterThan,
-            isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
-            arrayContains: arrayContains,
-            arrayContainsAny: arrayContainsAny,
-            whereIn: whereIn,
-            isNull: isNull))
-        .toList();
+    _QueryOperation operation = (documents) => documents.where((document) {
+          dynamic value;
+          if (field is String) {
+            value = document[field];
+          } else if (field == FieldPath.documentId) {
+            value = document.documentID;
+          }
+          return _valueMatchesQuery(value,
+              isEqualTo: isEqualTo,
+              isLessThan: isLessThan,
+              isLessThanOrEqualTo: isLessThanOrEqualTo,
+              isGreaterThan: isGreaterThan,
+              isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+              arrayContains: arrayContains,
+              arrayContainsAny: arrayContainsAny,
+              whereIn: whereIn,
+              isNull: isNull);
+        }).toList();
     return MockQuery(this, operation);
   }
 

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -93,8 +93,18 @@ class MockQuery extends Mock implements Query {
     return MockQuery(this, (documents) {
       final sortedList = List.of(documents);
       sortedList.sort((d1, d2) {
-        final value1 = d1.data[field] as Comparable;
-        final value2 = d2.data[field];
+        dynamic value1;
+        if (field is String) {
+          value1 = d1.data[field] as Comparable;
+        } else if (field == FieldPath.documentId) {
+          value1 = d1.documentID;
+        }
+        dynamic value2;
+        if (field is String) {
+          value2 = d2.data[field];
+        } else if (field == FieldPath.documentId) {
+          value2 = d2.documentID;
+        }
         if (value1 == null && value2 == null) {
           return 0;
         }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -326,6 +326,23 @@ void main() {
         }));
   });
 
+  test('where with FieldPath.documentID', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('users').document('1').setData({});
+    await instance.collection('users').document('2').setData({});
+    await instance.collection('users').document('3').setData({});
+
+    final snapshot = await instance
+        .collection('users')
+        .where(FieldPath.documentId, isEqualTo: '1')
+        .getDocuments();
+
+    final documents = snapshot.documents;
+
+    expect(documents.length, equals(1));
+    expect(documents.first.documentID, equals('1'));
+  });
+
   test('Collection.getDocuments', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').add({

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -174,6 +174,24 @@ void main() {
     ));
   });
 
+  test('orderBy returns documents sorted by documentID', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('users').document('3').setData({});
+    await instance.collection('users').document('2').setData({});
+    await instance.collection('users').document('1').setData({});
+
+    final query = instance.collection('users').orderBy(FieldPath.documentId);
+
+    query.snapshots().listen(expectAsync1(
+      (event) {
+        expect(event.documents[0].documentID, ('1'));
+        expect(event.documents[1].documentID, ('2'));
+        expect(event.documents[2].documentID, ('3'));
+        expect(event.documents.length, greaterThan(0));
+      },
+    ));
+  });
+
   test('arrayContains', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('posts').add({


### PR DESCRIPTION
Fixes: #89 