### PR TITLE
support oldIndex,newIndex of DocumentChange

### DIFF
--- a/example/test_driver/cloud_firestore.dart
+++ b/example/test_driver/cloud_firestore.dart
@@ -53,12 +53,10 @@ void main() {
       final querySnapshot = await query.getDocuments();
       expect(querySnapshot.metadata, isNotNull);
       expect(querySnapshot.documents.first['message'], 'Hello world!');
-      final firstDoc =
-          querySnapshot.documents.first.reference;
+      final firstDoc = querySnapshot.documents.first.reference;
       final documentSnapshot = await firstDoc.get();
       expect(documentSnapshot.data['message'], 'Hello world!');
-      final cachedSnapshot =
-          await firstDoc.get(source: Source.cache);
+      final cachedSnapshot = await firstDoc.get(source: Source.cache);
       expect(cachedSnapshot.data['message'], 'Hello world!');
       final snapshot = await firstDoc.snapshots().first;
       expect(snapshot.data['message'], 'Hello world!');
@@ -147,8 +145,7 @@ void main() {
       final dynamic result = await firestore.runTransaction(
         (Transaction tx) async {
           final snapshot = await tx.get(ref);
-          final updatedData =
-              Map<String, dynamic>.from(snapshot.data);
+          final updatedData = Map<String, dynamic>.from(snapshot.data);
           updatedData['message'] = 'testing2';
           await tx.update(ref, updatedData); // calling await here is optional
           return updatedData;

--- a/lib/src/mock_document_change.dart
+++ b/lib/src/mock_document_change.dart
@@ -3,11 +3,19 @@ import 'package:mockito/mockito.dart';
 
 class MockDocumentChange extends Mock implements DocumentChange {
   final DocumentSnapshot _document;
+  final int _oldIndex;
+  final int _newIndex;
 
-  MockDocumentChange(this._document);
+  MockDocumentChange(this._document, {int oldIndex, int newIndex}): _oldIndex = oldIndex, _newIndex = newIndex;
 
   @override
   DocumentChangeType get type => DocumentChangeType.added;
+
+  @override
+  int get oldIndex => _oldIndex;
+
+  @override
+  int get newIndex => _newIndex;
 
   @override
   DocumentSnapshot get document => _document;

--- a/lib/src/mock_document_change.dart
+++ b/lib/src/mock_document_change.dart
@@ -3,13 +3,20 @@ import 'package:mockito/mockito.dart';
 
 class MockDocumentChange extends Mock implements DocumentChange {
   final DocumentSnapshot _document;
+  final DocumentChangeType _type;
   final int _oldIndex;
   final int _newIndex;
 
-  MockDocumentChange(this._document, {int oldIndex, int newIndex}): _oldIndex = oldIndex, _newIndex = newIndex;
+  MockDocumentChange(
+    this._document,
+    this._type, {
+    int oldIndex,
+    int newIndex,
+  })  : _oldIndex = oldIndex,
+        _newIndex = newIndex;
 
   @override
-  DocumentChangeType get type => DocumentChangeType.added;
+  DocumentChangeType get type => _type;
 
   @override
   int get oldIndex => _oldIndex;

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -10,7 +10,8 @@ import 'package:quiver/core.dart';
 
 import 'mock_snapshot.dart';
 
-typedef _QueryOperation = List<DocumentSnapshot> Function(List<DocumentSnapshot> input);
+typedef _QueryOperation = List<DocumentSnapshot> Function(
+    List<DocumentSnapshot> input);
 
 class MockQuery extends Mock implements Query {
   /// Previous query in a Firestore query chain. Null if this instance is a

--- a/lib/src/mock_snapshot.dart
+++ b/lib/src/mock_snapshot.dart
@@ -14,7 +14,8 @@ class MockSnapshot extends Mock implements QuerySnapshot {
       _documentChanges.add(MockDocumentChange(
         document,
         DocumentChangeType.added,
-        oldIndex: -1, // See: https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/DocumentChange/oldIndex.html
+        oldIndex:
+            -1, // See: https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/DocumentChange/oldIndex.html
         newIndex: index,
       ));
     });

--- a/lib/src/mock_snapshot.dart
+++ b/lib/src/mock_snapshot.dart
@@ -13,7 +13,8 @@ class MockSnapshot extends Mock implements QuerySnapshot {
     _documents.asMap().forEach((index, document) {
       _documentChanges.add(MockDocumentChange(
         document,
-        oldIndex: -1, // See: https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/DocumentChange/oldIndex.html
+        DocumentChangeType.added,
+        oldIndex: -1, // // See: https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/DocumentChange/oldIndex.html
         newIndex: index,
       ));
     });

--- a/lib/src/mock_snapshot.dart
+++ b/lib/src/mock_snapshot.dart
@@ -14,7 +14,7 @@ class MockSnapshot extends Mock implements QuerySnapshot {
       _documentChanges.add(MockDocumentChange(
         document,
         DocumentChangeType.added,
-        oldIndex: -1, // // See: https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/DocumentChange/oldIndex.html
+        oldIndex: -1, // See: https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/DocumentChange/oldIndex.html
         newIndex: index,
       ));
     });

--- a/lib/src/mock_snapshot.dart
+++ b/lib/src/mock_snapshot.dart
@@ -8,8 +8,14 @@ class MockSnapshot extends Mock implements QuerySnapshot {
   final List<DocumentChange> _documentChanges = <DocumentChange>[];
 
   MockSnapshot(this._documents) {
-    _documents.forEach((document) {
-      _documentChanges.add(MockDocumentChange(document));
+    // TODO: support another change tyep (removed, modified).
+    // ref: https://pub.dev/documentation/cloud_firestore_platform_interface/latest/cloud_firestore_platform_interface/DocumentChangeType-class.html
+    _documents.asMap().forEach((index, document) {
+      _documentChanges.add(MockDocumentChange(
+        document,
+        oldIndex: -1, // See: https://pub.dev/documentation/cloud_firestore/latest/cloud_firestore/DocumentChange/oldIndex.html
+        newIndex: index,
+      ));
     });
   }
 

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -706,8 +706,7 @@ void main() {
         await firestore.collection('users').document(document1Id).get();
     expect(snapshot['someField'], 'someValue');
 
-    final querySnapshot =
-        await firestore.collection('users').getDocuments();
+    final querySnapshot = await firestore.collection('users').getDocuments();
     expect(querySnapshot.documents, hasLength(1));
     expect(querySnapshot.documents.first['someField'], 'someValue');
   });

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -142,6 +142,8 @@ void main() {
     instance.collection('users').snapshots().listen(expectAsync1((snap) {
       expect(snap.documentChanges.length, 1);
       expect(snap.documentChanges[0].type, DocumentChangeType.added);
+      expect(snap.documentChanges[0].oldIndex, -1);
+      expect(snap.documentChanges[0].newIndex, 0);
     }));
   });
   test('Snapshots sets exists property to false if the document does not exist',


### PR DESCRIPTION
solve https://github.com/atn832/cloud_firestore_mocks/issues/120 **_partialiy_**.

on this PR, to implement [DocumentChangeType](https://pub.dev/documentation/cloud_firestore_platform_interface/latest/cloud_firestore_platform_interface/DocumentChangeType-class.html) other than `added` is not supported.