### PR TITLE
support CollectionGroup Query

### DIFF
--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -40,6 +40,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
       this,
       collectionId,
       getSubpath(_root, collectionId, isCollectionGroup: true),
+      _docsData,
       getSubpath(_snapshotStreamControllerRoot, collectionId,
           isCollectionGroup: true),
       isCollectionGroup: true,

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -1,8 +1,7 @@
 import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
-    as firestore_interface;
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart' as firestore_interface;
 import 'package:flutter/services.dart';
 import 'package:mockito/mockito.dart';
 
@@ -29,8 +28,8 @@ class MockFirestoreInstance extends Mock implements Firestore {
     final segments = path.split('/');
     assert(segments.length % 2 == 1,
         'Invalid document reference. Collection references must have an odd number of segments');
-    return MockCollectionReference(this, path, getSubpath(_root, path),
-        _docsData, getSubpath(_snapshotStreamControllerRoot, path));
+    return MockCollectionReference(
+        this, path, getSubpath(_root, path), _docsData, getSubpath(_snapshotStreamControllerRoot, path));
   }
 
   @override
@@ -39,10 +38,9 @@ class MockFirestoreInstance extends Mock implements Firestore {
     return MockCollectionReference(
       this,
       collectionId,
-      getSubpath(_root, collectionId, isCollectionGroup: true),
+      buildTreeIncludingCollectionId(_root, _root, collectionId, {}),
       _docsData,
-      getSubpath(_snapshotStreamControllerRoot, collectionId,
-          isCollectionGroup: true),
+      buildTreeIncludingCollectionId(_snapshotStreamControllerRoot, _snapshotStreamControllerRoot, collectionId, {}),
       isCollectionGroup: true,
     );
   }
@@ -56,13 +54,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
     assert(segments.length % 2 == 0,
         'Invalid document reference. Document references must have an even number of segments');
     final documentId = segments.last;
-    return MockDocumentReference(
-        this,
-        path,
-        documentId,
-        getSubpath(_root, path),
-        _docsData,
-        _root,
+    return MockDocumentReference(this, path, documentId, getSubpath(_root, path), _docsData, _root,
         getSubpath(_snapshotStreamControllerRoot, path));
   }
 
@@ -72,8 +64,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   @override
-  Future<Map<String, dynamic>> runTransaction(
-      TransactionHandler transactionHandler,
+  Future<Map<String, dynamic>> runTransaction(TransactionHandler transactionHandler,
       {Duration timeout = const Duration(seconds: 5)}) async {
     Transaction transaction = _DummyTransaction();
     final handlerResult = await transactionHandler(transaction);
@@ -116,9 +107,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
       }
       return;
     }
-    throw PlatformException(
-        code: 'error',
-        message: 'Invalid argument: Instance of ${value.runtimeType}');
+    throw PlatformException(code: 'error', message: 'Invalid argument: Instance of ${value.runtimeType}');
   }
 
   String dump() {
@@ -158,8 +147,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   void _setupFieldValueFactory() {
-    firestore_interface.FieldValueFactoryPlatform.instance =
-        MockFieldValueFactoryPlatform();
+    firestore_interface.FieldValueFactoryPlatform.instance = MockFieldValueFactoryPlatform();
   }
 }
 
@@ -172,9 +160,7 @@ class _DummyTransaction implements Transaction {
   Future<DocumentSnapshot> get(DocumentReference documentReference) {
     if (_foundWrite) {
       throw PlatformException(
-          code: '3',
-          message:
-              'Firestore transactions require all reads to be executed before all writes');
+          code: '3', message: 'Firestore transactions require all reads to be executed before all writes');
     }
     return documentReference.get();
   }
@@ -186,15 +172,13 @@ class _DummyTransaction implements Transaction {
   }
 
   @override
-  Future<void> update(
-      DocumentReference documentReference, Map<String, dynamic> data) {
+  Future<void> update(DocumentReference documentReference, Map<String, dynamic> data) {
     _foundWrite = true;
     return documentReference.updateData(data);
   }
 
   @override
-  Future<void> set(
-      DocumentReference documentReference, Map<String, dynamic> data) {
+  Future<void> set(DocumentReference documentReference, Map<String, dynamic> data) {
     _foundWrite = true;
     return documentReference.setData(data);
   }

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -1,7 +1,8 @@
 import 'dart:convert';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart' as firestore_interface;
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
+    as firestore_interface;
 import 'package:flutter/services.dart';
 import 'package:mockito/mockito.dart';
 
@@ -28,8 +29,8 @@ class MockFirestoreInstance extends Mock implements Firestore {
     final segments = path.split('/');
     assert(segments.length % 2 == 1,
         'Invalid document reference. Collection references must have an odd number of segments');
-    return MockCollectionReference(
-        this, path, getSubpath(_root, path), _docsData, getSubpath(_snapshotStreamControllerRoot, path));
+    return MockCollectionReference(this, path, getSubpath(_root, path),
+        _docsData, getSubpath(_snapshotStreamControllerRoot, path));
   }
 
   @override
@@ -40,7 +41,8 @@ class MockFirestoreInstance extends Mock implements Firestore {
       collectionId,
       buildTreeIncludingCollectionId(_root, _root, collectionId, {}),
       _docsData,
-      buildTreeIncludingCollectionId(_snapshotStreamControllerRoot, _snapshotStreamControllerRoot, collectionId, {}),
+      buildTreeIncludingCollectionId(_snapshotStreamControllerRoot,
+          _snapshotStreamControllerRoot, collectionId, {}),
       isCollectionGroup: true,
     );
   }
@@ -54,7 +56,13 @@ class MockFirestoreInstance extends Mock implements Firestore {
     assert(segments.length % 2 == 0,
         'Invalid document reference. Document references must have an even number of segments');
     final documentId = segments.last;
-    return MockDocumentReference(this, path, documentId, getSubpath(_root, path), _docsData, _root,
+    return MockDocumentReference(
+        this,
+        path,
+        documentId,
+        getSubpath(_root, path),
+        _docsData,
+        _root,
         getSubpath(_snapshotStreamControllerRoot, path));
   }
 
@@ -64,7 +72,8 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   @override
-  Future<Map<String, dynamic>> runTransaction(TransactionHandler transactionHandler,
+  Future<Map<String, dynamic>> runTransaction(
+      TransactionHandler transactionHandler,
       {Duration timeout = const Duration(seconds: 5)}) async {
     Transaction transaction = _DummyTransaction();
     final handlerResult = await transactionHandler(transaction);
@@ -107,7 +116,9 @@ class MockFirestoreInstance extends Mock implements Firestore {
       }
       return;
     }
-    throw PlatformException(code: 'error', message: 'Invalid argument: Instance of ${value.runtimeType}');
+    throw PlatformException(
+        code: 'error',
+        message: 'Invalid argument: Instance of ${value.runtimeType}');
   }
 
   String dump() {
@@ -147,7 +158,8 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   void _setupFieldValueFactory() {
-    firestore_interface.FieldValueFactoryPlatform.instance = MockFieldValueFactoryPlatform();
+    firestore_interface.FieldValueFactoryPlatform.instance =
+        MockFieldValueFactoryPlatform();
   }
 }
 
@@ -160,7 +172,9 @@ class _DummyTransaction implements Transaction {
   Future<DocumentSnapshot> get(DocumentReference documentReference) {
     if (_foundWrite) {
       throw PlatformException(
-          code: '3', message: 'Firestore transactions require all reads to be executed before all writes');
+          code: '3',
+          message:
+              'Firestore transactions require all reads to be executed before all writes');
     }
     return documentReference.get();
   }
@@ -172,13 +186,15 @@ class _DummyTransaction implements Transaction {
   }
 
   @override
-  Future<void> update(DocumentReference documentReference, Map<String, dynamic> data) {
+  Future<void> update(
+      DocumentReference documentReference, Map<String, dynamic> data) {
     _foundWrite = true;
     return documentReference.updateData(data);
   }
 
   @override
-  Future<void> set(DocumentReference documentReference, Map<String, dynamic> data) {
+  Future<void> set(
+      DocumentReference documentReference, Map<String, dynamic> data) {
     _foundWrite = true;
     return documentReference.setData(data);
   }

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -33,6 +33,19 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   @override
+  CollectionReference collectionGroup(String collectionId) {
+    assert(!collectionId.contains('/'), 'Collection ID should not contain "/"');
+    return MockCollectionReference(
+      this,
+      collectionId,
+      getSubpath(_root, collectionId, isCollectionGroup: true),
+      getSubpath(_snapshotStreamControllerRoot, collectionId,
+          isCollectionGroup: true),
+      isCollectionGroup: true,
+    );
+  }
+
+  @override
   DocumentReference document(String path) {
     final segments = path.split('/');
     // The actual behavior of Firestore for an invalid number of segments

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -71,8 +71,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       documents = _buildDocumentsForCollectionGroup(root, []);
     } else {
       documents = root.entries.map((entry) {
-        MockDocumentReference documentReference = _documentReference(
-            _firestore, _path, entry.key, root, docsData, snapshotStreamControllerRoot, _isCollectionGroup);
+        MockDocumentReference documentReference = _documentReference(_path, entry.key, root);
         return MockDocumentSnapshot(
           documentReference,
           entry.key,
@@ -94,8 +93,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       final isEntryADocument = entry.value is! Map<String, dynamic>;
       if (isEntryADocument) continue;
       if (pathSegments.last == _collectionId) {
-        final documentReference = _documentReference(
-            _firestore, path, entry.key, node, docsData, snapshotStreamControllerRoot, _isCollectionGroup);
+        final documentReference = _documentReference(path, entry.key, node);
         if (!docsData.keys.contains(documentReference.path)) continue;
         result.add(MockDocumentSnapshot(
           documentReference,
@@ -124,18 +122,10 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
   @override
   DocumentReference document([String path]) {
     final documentId = (path == null) ? _generateAutoId() : path;
-    return _documentReference(
-        _firestore, _path, documentId, root, docsData, snapshotStreamControllerRoot, _isCollectionGroup);
+    return _documentReference(_path, documentId, root);
   }
 
-  static DocumentReference _documentReference(
-      MockFirestoreInstance firestore,
-      String collectionFullPath,
-      String documentId,
-      Map<String, dynamic> root,
-      Map<String, dynamic> docsData,
-      Map<String, dynamic> snapshotStreamControllerRoot,
-      bool isCollectionGroup) {
+  DocumentReference _documentReference(String collectionFullPath, String documentId, Map<String, dynamic> root) {
     final fullPath = [collectionFullPath, documentId].join('/');
     return MockDocumentReference(
       firestore,

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -100,9 +100,10 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
         node.entries.where((entry) => entry.value is Map<String, dynamic>);
     if (pathSegments.last == _collectionId) {
       final documentReferences = entriesWithoutDocumentValue
-          .map((entry) => _documentReference(path, entry.key, node));
+          .map((entry) => _documentReference(path, entry.key, node))
+          .where((documentReference) =>
+              docsData.keys.contains(documentReference.path));
       for (final documentReference in documentReferences) {
-        if (!docsData.keys.contains(documentReference.path)) continue;
         result.add(MockDocumentSnapshot(
           documentReference,
           documentReference.documentID,

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -28,12 +28,14 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
 
   StreamController<QuerySnapshot> get snapshotStreamController {
     if (!snapshotStreamControllerRoot.containsKey(snapshotsStreamKey)) {
-      snapshotStreamControllerRoot[snapshotsStreamKey] = StreamController<QuerySnapshot>.broadcast();
+      snapshotStreamControllerRoot[snapshotsStreamKey] =
+          StreamController<QuerySnapshot>.broadcast();
     }
     return snapshotStreamControllerRoot[snapshotsStreamKey];
   }
 
-  MockCollectionReference(this._firestore, this._path, this.root, this.docsData, this.snapshotStreamControllerRoot,
+  MockCollectionReference(this._firestore, this._path, this.root, this.docsData,
+      this.snapshotStreamControllerRoot,
       {isCollectionGroup = false})
       : _isCollectionGroup = isCollectionGroup,
         super();
@@ -65,13 +67,15 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
   }
 
   @override
-  Future<QuerySnapshot> getDocuments({Source source = Source.serverAndCache}) async {
+  Future<QuerySnapshot> getDocuments(
+      {Source source = Source.serverAndCache}) async {
     var documents = <MockDocumentSnapshot>[];
     if (_isCollectionGroup) {
       documents = _buildDocumentsForCollectionGroup(root, []);
     } else {
       documents = root.entries.map((entry) {
-        MockDocumentReference documentReference = _documentReference(_path, entry.key, root);
+        MockDocumentReference documentReference =
+            _documentReference(_path, entry.key, root);
         return MockDocumentSnapshot(
           documentReference,
           entry.key,
@@ -81,7 +85,10 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       }).toList();
     }
     return MockSnapshot(
-      documents.where((snapshot) => _firestore.hasSavedDocument(snapshot.reference.path)).toList(),
+      documents
+          .where((snapshot) =>
+              _firestore.hasSavedDocument(snapshot.reference.path))
+          .toList(),
     );
   }
 
@@ -89,9 +96,11 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       Map<String, dynamic> node, List<MockDocumentSnapshot> result,
       [String path = '']) {
     final pathSegments = path.split('/');
-    final entriesWithoutDocumentValue = node.entries.where((entry) => entry.value is Map<String, dynamic>);
+    final entriesWithoutDocumentValue =
+        node.entries.where((entry) => entry.value is Map<String, dynamic>);
     if (pathSegments.last == _collectionId) {
-      final documentReferences = entriesWithoutDocumentValue.map((entry) => _documentReference(path, entry.key, node));
+      final documentReferences = entriesWithoutDocumentValue
+          .map((entry) => _documentReference(path, entry.key, node));
       for (final documentReference in documentReferences) {
         if (!docsData.keys.contains(documentReference.path)) continue;
         result.add(MockDocumentSnapshot(
@@ -113,10 +122,13 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
   }
 
   static final Random _random = Random();
-  static final String _autoIdCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  static final String _autoIdCharacters =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
   static String _generateAutoId() {
     final maxIndex = _autoIdCharacters.length - 1;
-    final autoId = List<int>.generate(20, (_) => _random.nextInt(maxIndex)).map((i) => _autoIdCharacters[i]).join();
+    final autoId = List<int>.generate(20, (_) => _random.nextInt(maxIndex))
+        .map((i) => _autoIdCharacters[i])
+        .join();
     return autoId;
   }
 
@@ -126,7 +138,8 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
     return _documentReference(_path, documentId, root);
   }
 
-  DocumentReference _documentReference(String collectionFullPath, String documentId, Map<String, dynamic> root) {
+  DocumentReference _documentReference(
+      String collectionFullPath, String documentId, Map<String, dynamic> root) {
     final fullPath = [collectionFullPath, documentId].join('/');
     return MockDocumentReference(
       firestore,

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -113,10 +113,12 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       }
     }
     for (final entry in documentOrCollectionEntries) {
+      final segment = entry.key;
+      final subCollection = entry.value;
       _buildDocumentsForCollectionGroup(
-        entry.value,
+        subCollection,
         result,
-        path.isEmpty ? entry.key : '$path/${entry.key}',
+        path.isEmpty ? segment : '$path/${segment}',
       );
     }
     return result;

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -96,10 +96,10 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       Map<String, dynamic> node, List<MockDocumentSnapshot> result,
       [String path = '']) {
     final pathSegments = path.split('/');
-    final entriesWithoutDocumentValue =
+    final documentOrCollectionEntries =
         node.entries.where((entry) => entry.value is Map<String, dynamic>);
     if (pathSegments.last == _collectionId) {
-      final documentReferences = entriesWithoutDocumentValue
+      final documentReferences = documentOrCollectionEntries
           .map((entry) => _documentReference(path, entry.key, node))
           .where((documentReference) =>
               docsData.keys.contains(documentReference.path));
@@ -112,7 +112,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
         ));
       }
     }
-    for (final entry in entriesWithoutDocumentValue) {
+    for (final entry in documentOrCollectionEntries) {
       _buildDocumentsForCollectionGroup(
         entry.value,
         result,

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -89,19 +89,20 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       Map<String, dynamic> node, List<MockDocumentSnapshot> result,
       [String path = '']) {
     final pathSegments = path.split('/');
-    for (final entry in node.entries) {
-      final isEntryADocument = entry.value is! Map<String, dynamic>;
-      if (isEntryADocument) continue;
-      if (pathSegments.last == _collectionId) {
-        final documentReference = _documentReference(path, entry.key, node);
+    final entriesWithoutDocumentValue = node.entries.where((entry) => entry.value is Map<String, dynamic>);
+    if (pathSegments.last == _collectionId) {
+      final documentReferences = entriesWithoutDocumentValue.map((entry) => _documentReference(path, entry.key, node));
+      for (final documentReference in documentReferences) {
         if (!docsData.keys.contains(documentReference.path)) continue;
         result.add(MockDocumentSnapshot(
           documentReference,
-          entry.key,
+          documentReference.documentID,
           docsData[documentReference.path],
           _firestore.hasSavedDocument(documentReference.path),
         ));
       }
+    }
+    for (final entry in entriesWithoutDocumentValue) {
       _buildDocumentsForCollectionGroup(
         entry.value,
         result,

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -71,8 +71,8 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       documents = _buildDocumentsForCollectionGroup(root, []);
     } else {
       documents = root.entries.map((entry) {
-        MockDocumentReference documentReference =
-            _documentReference(_firestore, _path, entry.key, root, docsData, snapshotStreamControllerRoot);
+        MockDocumentReference documentReference = _documentReference(
+            _firestore, _path, entry.key, root, docsData, snapshotStreamControllerRoot, _isCollectionGroup);
         return MockDocumentSnapshot(
           documentReference,
           entry.key,
@@ -93,8 +93,8 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
     for (final entry in node.entries) {
       if (entry.value is! Map<String, dynamic>) continue;
       if (pathSegments.last == _collectionId) {
-        final documentReference =
-            _documentReference(_firestore, path, entry.key, node, docsData, snapshotStreamControllerRoot);
+        final documentReference = _documentReference(
+            _firestore, path, entry.key, node, docsData, snapshotStreamControllerRoot, _isCollectionGroup);
         result.add(MockDocumentSnapshot(
           documentReference,
           entry.key,
@@ -122,7 +122,8 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
   @override
   DocumentReference document([String path]) {
     final documentId = (path == null) ? _generateAutoId() : path;
-    return _documentReference(_firestore, _path, documentId, root, docsData, snapshotStreamControllerRoot);
+    return _documentReference(
+        _firestore, _path, documentId, root, docsData, snapshotStreamControllerRoot, _isCollectionGroup);
   }
 
   static DocumentReference _documentReference(
@@ -131,10 +132,18 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       String documentId,
       Map<String, dynamic> root,
       Map<String, dynamic> docsData,
-      Map<String, dynamic> snapshotStreamControllerRoot) {
+      Map<String, dynamic> snapshotStreamControllerRoot,
+      bool isCollectionGroup) {
     final fullPath = [collectionFullPath, documentId].join('/');
-    return MockDocumentReference(firestore, fullPath, documentId, getSubpath(root, documentId), docsData, root,
-        getSubpath(snapshotStreamControllerRoot, documentId));
+    return MockDocumentReference(
+      firestore,
+      fullPath,
+      documentId,
+      getSubpath(root, documentId),
+      docsData,
+      root,
+      getSubpath(snapshotStreamControllerRoot, documentId),
+    );
   }
 
   @override

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -96,8 +96,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       Map<String, dynamic> node, List<MockDocumentSnapshot> result,
       [String path = '']) {
     final pathSegments = path.split('/');
-    final documentOrCollectionEntries =
-        node.entries.where((entry) => entry.value is Map<String, dynamic>);
+    final documentOrCollectionEntries = node.entries;
     if (pathSegments.last == _collectionId) {
       final documentReferences = documentOrCollectionEntries
           .map((entry) => _documentReference(path, entry.key, node))

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -91,7 +91,8 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       [String path = '']) {
     final pathSegments = path.split('/');
     for (final entry in node.entries) {
-      if (entry.value is! Map<String, dynamic>) continue;
+      final isEntryADocument = entry.value is! Map<String, dynamic>;
+      if (isEntryADocument) continue;
       if (pathSegments.last == _collectionId) {
         final documentReference = _documentReference(
             _firestore, path, entry.key, node, docsData, snapshotStreamControllerRoot, _isCollectionGroup);

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -68,16 +68,16 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
   @override
   Future<QuerySnapshot> getDocuments(
       {Source source = Source.serverAndCache}) async {
-    final documents = <MockDocumentSnapshot>[];
+    var documents = <MockDocumentSnapshot>[];
     if (_isCollectionGroup) {
-      documents.addAll(_buildDocumentsForCollectionGroup(root, []));
+      documents = _buildDocumentsForCollectionGroup(root, []);
     } else {
-      root.entries.forEach((entry) {
+      documents = root.entries.map((entry) {
         MockDocumentReference documentReference = _documentReference(
             _firestore, _path, entry.key, root, snapshotStreamControllerRoot);
-        documents.add(MockDocumentSnapshot(
-            documentReference, entry.key, entry.value, true));
-      });
+        return MockDocumentSnapshot(
+            documentReference, entry.key, entry.value, true);
+      }).toList();
     }
     return MockSnapshot(
       documents

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -96,6 +96,7 @@ class MockCollectionReference extends MockQuery implements CollectionReference {
       if (pathSegments.last == _collectionId) {
         final documentReference = _documentReference(
             _firestore, path, entry.key, node, docsData, snapshotStreamControllerRoot, _isCollectionGroup);
+        if (!docsData.keys.contains(documentReference.path)) continue;
         result.add(MockDocumentSnapshot(
           documentReference,
           entry.key,

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -140,26 +140,25 @@ class MockQuery extends Mock implements Query {
       List<dynamic> arrayContainsAny,
       List<dynamic> whereIn,
       bool isNull}) {
-    final operation = (List<DocumentSnapshot> documents) => documents
-        .where((document) {
-          dynamic value;
-          if (field is String) {
-            value = document[field];
-          } else if (field == FieldPath.documentId) {
-            value = document.documentID;
-          }
-          return _valueMatchesQuery(value,
-            isEqualTo: isEqualTo,
-            isLessThan: isLessThan,
-            isLessThanOrEqualTo: isLessThanOrEqualTo,
-            isGreaterThan: isGreaterThan,
-            isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
-            arrayContains: arrayContains,
-            arrayContainsAny: arrayContainsAny,
-            whereIn: whereIn,
-            isNull: isNull);
-        })
-        .toList();
+    final operation =
+        (List<DocumentSnapshot> documents) => documents.where((document) {
+              dynamic value;
+              if (field is String) {
+                value = document[field];
+              } else if (field == FieldPath.documentId) {
+                value = document.documentID;
+              }
+              return _valueMatchesQuery(value,
+                  isEqualTo: isEqualTo,
+                  isLessThan: isLessThan,
+                  isLessThanOrEqualTo: isLessThanOrEqualTo,
+                  isGreaterThan: isGreaterThan,
+                  isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
+                  arrayContains: arrayContains,
+                  arrayContainsAny: arrayContainsAny,
+                  whereIn: whereIn,
+                  isNull: isNull);
+            }).toList();
     return MockQuery(this, operation);
   }
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,13 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:flutter/foundation.dart';
 
-dynamic getSubpath(Map<String, dynamic> root, String path, {bool isCollectionGroup = false}) {
-  final pathSegments = path.split('/');
-  if (isCollectionGroup) {
-    final result = buildSubpathForCollectionGroup(root, root, pathSegments.first, {});
-    return result;
-  }
-  return _getSubpath(root, pathSegments);
+dynamic getSubpath(Map<String, dynamic> root, String path) {
+  return _getSubpath(root, path.split('/'));
 }
 
 dynamic _getSubpath(Map<String, dynamic> node, List<String> pathSegments) {
@@ -22,9 +16,7 @@ dynamic _getSubpath(Map<String, dynamic> node, List<String> pathSegments) {
   }
 }
 
-// build paths which contain collectionId
-@visibleForTesting
-Map<String, dynamic> buildSubpathForCollectionGroup(
+Map<String, dynamic> buildTreeIncludingCollectionId(
     Map<String, dynamic> root, Map<String, dynamic> node, String collectionId, Map<String, dynamic> result,
     [String path = '']) {
   final pathSegments = path.isEmpty ? [collectionId] : path.split('/');
@@ -33,7 +25,7 @@ Map<String, dynamic> buildSubpathForCollectionGroup(
       result[pathSegments.first] = root[pathSegments.first];
     }
     if (entry.value is Map<String, dynamic>) {
-      buildSubpathForCollectionGroup(
+      buildTreeIncludingCollectionId(
         root,
         entry.value,
         collectionId,

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -21,7 +21,7 @@ Map<String, dynamic> buildTreeIncludingCollectionId(
     [String path = '']) {
   final pathSegments = path.isEmpty ? [collectionId] : path.split('/');
   for (final entry in node.entries) {
-    if (pathSegments.isNotEmpty && pathSegments[pathSegments.length - 1] == collectionId) {
+    if (pathSegments.last == collectionId) {
       result[pathSegments.first] = root[pathSegments.first];
     }
     if (entry.value is Map<String, dynamic>) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -24,9 +24,9 @@ Map<String, dynamic> buildTreeIncludingCollectionId(Map<String, dynamic> root,
     result[pathSegments.first] = root[pathSegments.first];
   }
 
-  final entriesWithoutDocumentValue =
+  final documentOrCollectionEntries =
       node.entries.where((entry) => entry.value is Map<String, dynamic>);
-  for (final entry in entriesWithoutDocumentValue) {
+  for (final entry in documentOrCollectionEntries) {
     buildTreeIncludingCollectionId(
       root,
       entry.value,

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,11 +1,11 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/foundation.dart';
 
-dynamic getSubpath(Map<String, dynamic> root, String path,
-    {bool isCollectionGroup = false}) {
+dynamic getSubpath(Map<String, dynamic> root, String path, {bool isCollectionGroup = false}) {
   final pathSegments = path.split('/');
   if (isCollectionGroup) {
-    return buildSubpathForCollectionGroup(root, root, pathSegments.first, {});
+    final result = buildSubpathForCollectionGroup(root, root, pathSegments.first, {});
+    return result;
   }
   return _getSubpath(root, pathSegments);
 }
@@ -24,13 +24,12 @@ dynamic _getSubpath(Map<String, dynamic> node, List<String> pathSegments) {
 
 // build paths which contain collectionId
 @visibleForTesting
-Map<String, dynamic> buildSubpathForCollectionGroup(Map<String, dynamic> root,
-    Map<String, dynamic> node, String collectionId, Map<String, dynamic> result,
+Map<String, dynamic> buildSubpathForCollectionGroup(
+    Map<String, dynamic> root, Map<String, dynamic> node, String collectionId, Map<String, dynamic> result,
     [String path = '']) {
-  final pathSegments = path.split('/');
+  final pathSegments = path.isEmpty ? [collectionId] : path.split('/');
   for (final entry in node.entries) {
-    if (pathSegments.length > 1 &&
-        pathSegments[pathSegments.length - 2] == collectionId) {
+    if (pathSegments.isNotEmpty && pathSegments[pathSegments.length - 1] == collectionId) {
       result[pathSegments.first] = root[pathSegments.first];
     }
     if (entry.value is Map<String, dynamic>) {

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -16,15 +16,16 @@ dynamic _getSubpath(Map<String, dynamic> node, List<String> pathSegments) {
   }
 }
 
-Map<String, dynamic> buildTreeIncludingCollectionId(
-    Map<String, dynamic> root, Map<String, dynamic> node, String collectionId, Map<String, dynamic> result,
+Map<String, dynamic> buildTreeIncludingCollectionId(Map<String, dynamic> root,
+    Map<String, dynamic> node, String collectionId, Map<String, dynamic> result,
     [String path = '']) {
   final pathSegments = path.isEmpty ? [collectionId] : path.split('/');
   if (pathSegments.last == collectionId) {
     result[pathSegments.first] = root[pathSegments.first];
   }
 
-  final entriesWithoutDocumentValue = node.entries.where((entry) => entry.value is Map<String, dynamic>);
+  final entriesWithoutDocumentValue =
+      node.entries.where((entry) => entry.value is Map<String, dynamic>);
   for (final entry in entriesWithoutDocumentValue) {
     buildTreeIncludingCollectionId(
       root,

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -20,19 +20,19 @@ Map<String, dynamic> buildTreeIncludingCollectionId(
     Map<String, dynamic> root, Map<String, dynamic> node, String collectionId, Map<String, dynamic> result,
     [String path = '']) {
   final pathSegments = path.isEmpty ? [collectionId] : path.split('/');
-  for (final entry in node.entries) {
-    if (pathSegments.last == collectionId) {
-      result[pathSegments.first] = root[pathSegments.first];
-    }
-    if (entry.value is Map<String, dynamic>) {
-      buildTreeIncludingCollectionId(
-        root,
-        entry.value,
-        collectionId,
-        result,
-        path.isEmpty ? entry.key : '$path/${entry.key}',
-      );
-    }
+  if (pathSegments.last == collectionId) {
+    result[pathSegments.first] = root[pathSegments.first];
+  }
+
+  final entriesWithoutDocumentValue = node.entries.where((entry) => entry.value is Map<String, dynamic>);
+  for (final entry in entriesWithoutDocumentValue) {
+    buildTreeIncludingCollectionId(
+      root,
+      entry.value,
+      collectionId,
+      result,
+      path.isEmpty ? entry.key : '$path/${entry.key}',
+    );
   }
   return result;
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -74,8 +74,7 @@ void main() {
       // act
       final docId = await collectionRef.add(data);
       // assert
-      final docSnap =
-          await instance.collection('users').document(docId.documentID).get();
+      final docSnap = await instance.collection('users').document(docId.documentID).get();
       expect(docSnap.data['username'], 'johndoe');
       expect(docSnap.data['joined'], isA<Timestamp>());
     });
@@ -96,11 +95,7 @@ void main() {
         .document('2')
         .setData({'label': 'relationship2'});
     expect(
-        firestore
-            .collection('userProfiles')
-            .document('a')
-            .collection('relationship')
-            .snapshots(),
+        firestore.collection('userProfiles').document('a').collection('relationship').snapshots(),
         emits(QuerySnapshotMatcher([
           DocumentSnapshotMatcher('1', {
             'label': 'relationship1',
@@ -146,32 +141,22 @@ void main() {
       expect(snap.documentChanges[0].newIndex, 0);
     }));
   });
-  test('Snapshots sets exists property to false if the document does not exist',
-      () async {
+  test('Snapshots sets exists property to false if the document does not exist', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').document(uid).setData({
       'name': 'Bob',
     });
-    instance
-        .collection('users')
-        .document('doesnotexist')
-        .snapshots()
-        .listen(expectAsync1((document) {
+    instance.collection('users').document('doesnotexist').snapshots().listen(expectAsync1((document) {
       expect(document.exists, equals(false));
     }));
   });
 
-  test('Snapshots sets exists property to true if the document does  exist',
-      () async {
+  test('Snapshots sets exists property to true if the document does  exist', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').document(uid).setData({
       'name': 'Bob',
     });
-    instance
-        .collection('users')
-        .document(uid)
-        .snapshots()
-        .listen(expectAsync1((document) {
+    instance.collection('users').document(uid).snapshots().listen(expectAsync1((document) {
       expect(document.exists, equals(true));
     }));
   });
@@ -187,8 +172,7 @@ void main() {
         .document('ccc');
 
     expect(documentReference.path, 'users/aaa/friends/bbb/friends-friends/ccc');
-    expect(documentReference.parent().path,
-        'users/aaa/friends/bbb/friends-friends');
+    expect(documentReference.parent().path, 'users/aaa/friends/bbb/friends-friends');
   });
 
   test('Document and collection parent()', () async {
@@ -210,8 +194,7 @@ void main() {
 
   test('firestore field', () async {
     final instance = MockFirestoreInstance();
-    final documentReference =
-        instance.collection('users').document('aaa').collection('friends');
+    final documentReference = instance.collection('users').document('aaa').collection('friends');
 
     expect(documentReference.firestore, instance);
     expect(documentReference.parent().firestore, instance);
@@ -219,11 +202,7 @@ void main() {
 
   test('Document reference equality', () async {
     final instance = MockFirestoreInstance();
-    final documentReference1 = instance
-        .collection('users')
-        .document('aaa')
-        .collection('friends')
-        .document('xyz');
+    final documentReference1 = instance.collection('users').document('aaa').collection('friends').document('xyz');
     final documentReference2 = instance.document('users/aaa/friends/xyz');
 
     expect(documentReference1, equals(documentReference2));
@@ -246,28 +225,18 @@ void main() {
   test('Saving documents in subcollection', () async {
     final instance = MockFirestoreInstance();
     // Creates 1st document in "users/abc/friends/<documentId>"
-    await instance
-        .collection('users')
-        .document(uid)
-        .collection('friends')
-        .add(<String, dynamic>{'name': 'Foo'});
+    await instance.collection('users').document(uid).collection('friends').add(<String, dynamic>{'name': 'Foo'});
 
     // The command above does not create a document at "users/abc"
-    final intermediateDocument =
-        await instance.collection('users').document(uid).get();
+    final intermediateDocument = await instance.collection('users').document(uid).get();
     expect(intermediateDocument.exists, false);
 
     // Gets a reference to an unsaved document.
     // This shouldn't appear in getDocuments
-    final documentReference = instance
-        .collection('users')
-        .document(uid)
-        .collection('friends')
-        .document('xyz');
+    final documentReference = instance.collection('users').document(uid).collection('friends').document('xyz');
     expect(documentReference.path, 'users/$uid/friends/xyz');
 
-    var subcollection =
-        instance.collection('users').document(uid).collection('friends');
+    var subcollection = instance.collection('users').document(uid).collection('friends');
     var querySnapshot = await subcollection.getDocuments();
     expect(querySnapshot.documents, hasLength(1));
 
@@ -276,8 +245,7 @@ void main() {
 
     // TODO: Remove the line below once MockQuery defers query execution.
     // https://github.com/atn832/cloud_firestore_mocks/issues/31
-    subcollection =
-        instance.collection('users').document(uid).collection('friends');
+    subcollection = instance.collection('users').document(uid).collection('friends');
     querySnapshot = await subcollection.getDocuments();
     expect(querySnapshot.documents, hasLength(2));
   });
@@ -292,11 +260,7 @@ void main() {
       }
     });
 
-    final documentReference = instance
-        .collection('users')
-        .document(uid)
-        .collection('friends')
-        .document('xyz');
+    final documentReference = instance.collection('users').document(uid).collection('friends').document('xyz');
 
     final snapshot = await documentReference.get();
     expect(snapshot.data['name'], 'Foo');
@@ -308,8 +272,7 @@ void main() {
     final nonExistentId = 'nonExistentId';
     final instance = MockFirestoreInstance();
 
-    final snapshot1 =
-        await instance.collection('users').document(nonExistentId).get();
+    final snapshot1 = await instance.collection('users').document(nonExistentId).get();
     expect(snapshot1, isNotNull);
     expect(snapshot1.documentID, nonExistentId);
     // data field should be null before the document is saved
@@ -366,9 +329,7 @@ void main() {
     test('FieldValue.delete() deletes key values', () async {
       final firestore = MockFirestoreInstance();
       await firestore.document('root/foo').setData({'flower': 'rose'});
-      await firestore
-          .document('root/foo')
-          .setData({'flower': FieldValue.delete()});
+      await firestore.document('root/foo').setData({'flower': FieldValue.delete()});
       final document = await firestore.document('root/foo').get();
       expect(document.data.isEmpty, equals(true));
     });
@@ -382,8 +343,7 @@ void main() {
       final bob = users.documents.first;
       expect(bob['created'], isNotNull);
       final bobCreated = bob['created'] as Timestamp; // Not DateTime
-      final timeDiff = Timestamp.now().millisecondsSinceEpoch -
-          bobCreated.millisecondsSinceEpoch;
+      final timeDiff = Timestamp.now().millisecondsSinceEpoch - bobCreated.millisecondsSinceEpoch;
       // Mock is fast it shouldn't take more than 1000 milliseconds to execute the code above
       expect(timeDiff, lessThan(1000));
     });
@@ -475,8 +435,7 @@ void main() {
 
     test('FieldValue in nested objects', () async {
       final firestore = MockFirestoreInstance();
-      final docRef =
-          firestore.collection('MyCollection').document('MyDocument');
+      final docRef = firestore.collection('MyCollection').document('MyDocument');
       final batch = firestore.batch();
 
       batch.setData(
@@ -508,28 +467,24 @@ void main() {
 
   test('setData to nested documents', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
-      'foo.bar.baz.username': 'SomeName',
-      'foo.bar.created': FieldValue.serverTimestamp()
-    });
+    await instance
+        .collection('users')
+        .document(uid)
+        .setData({'foo.bar.baz.username': 'SomeName', 'foo.bar.created': FieldValue.serverTimestamp()});
 
     final snapshot = await instance.collection('users').getDocuments();
     expect(snapshot.documents.length, equals(1));
     final topLevelDocument = snapshot.documents.first;
     expect(topLevelDocument['foo'], isNotNull);
-    final secondLevelDocument =
-        topLevelDocument['foo'] as Map<dynamic, dynamic>;
+    final secondLevelDocument = topLevelDocument['foo'] as Map<dynamic, dynamic>;
     expect(secondLevelDocument['bar'], isNotNull);
-    final thirdLevelDocument =
-        secondLevelDocument['bar'] as Map<dynamic, dynamic>;
+    final thirdLevelDocument = secondLevelDocument['bar'] as Map<dynamic, dynamic>;
     expect(thirdLevelDocument['baz'], isNotNull);
-    final fourthLevelDocument =
-        thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
+    final fourthLevelDocument = thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
     expect(fourthLevelDocument['username'], 'SomeName');
 
     final barCreated = thirdLevelDocument['created'] as Timestamp;
-    final timeDiff = Timestamp.now().millisecondsSinceEpoch -
-        barCreated.millisecondsSinceEpoch;
+    final timeDiff = Timestamp.now().millisecondsSinceEpoch - barCreated.millisecondsSinceEpoch;
     // Mock is fast it shouldn't take more than 1000 milliseconds to execute the code above
     expect(timeDiff, lessThan(1000));
   });
@@ -550,14 +505,11 @@ void main() {
     expect(snapshot.documents.length, equals(1));
     final topLevelDocument = snapshot.documents.first;
     expect(topLevelDocument['foo'], isNotNull);
-    final secondLevelDocument =
-        topLevelDocument['foo'] as Map<dynamic, dynamic>;
+    final secondLevelDocument = topLevelDocument['foo'] as Map<dynamic, dynamic>;
     expect(secondLevelDocument['bar'], isNotNull);
-    final thirdLevelDocument =
-        secondLevelDocument['bar'] as Map<dynamic, dynamic>;
+    final thirdLevelDocument = secondLevelDocument['bar'] as Map<dynamic, dynamic>;
     expect(thirdLevelDocument['baz'], isNotNull);
-    final fourthLevelDocument =
-        thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
+    final fourthLevelDocument = thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
     expect(fourthLevelDocument['username'], 'SomeName');
 
     // UpdateData should create the expected object
@@ -565,14 +517,11 @@ void main() {
     expect(snapshot2.documents.length, equals(1));
     final topLevelDocument2 = snapshot2.documents.first;
     expect(topLevelDocument2['foo'], isNotNull);
-    final secondLevelDocument2 =
-        topLevelDocument2['foo'] as Map<dynamic, dynamic>;
+    final secondLevelDocument2 = topLevelDocument2['foo'] as Map<dynamic, dynamic>;
     expect(secondLevelDocument2['bar'], isNotNull);
-    final thirdLevelDocument2 =
-        secondLevelDocument2['bar'] as Map<dynamic, dynamic>;
+    final thirdLevelDocument2 = secondLevelDocument2['bar'] as Map<dynamic, dynamic>;
     expect(thirdLevelDocument2['BAZ'], isNotNull);
-    final fourthLevelDocument2 =
-        thirdLevelDocument2['BAZ'] as Map<dynamic, dynamic>;
+    final fourthLevelDocument2 = thirdLevelDocument2['BAZ'] as Map<dynamic, dynamic>;
     expect(fourthLevelDocument2['username'], 'AnotherName');
   });
 
@@ -673,16 +622,13 @@ void main() {
           }
         }
       ];
-      expect(result.data['array'], expected,
-          reason: 'Array modification should not affect ${reasons[i]}');
+      expect(result.data['array'], expected, reason: 'Array modification should not affect ${reasons[i]}');
 
       final map1 = result.data['map'] as Map<String, dynamic>;
-      expect(map1['k1'], 'old value 1',
-          reason: 'Map modification should not affect ${reasons[i]}');
+      expect(map1['k1'], 'old value 1', reason: 'Map modification should not affect ${reasons[i]}');
       final map2 = map1['nested1'] as Map<String, dynamic>;
       final map3 = map2['nested2'] as Map<String, dynamic>;
-      expect(map3['k2'], 'old value 2',
-          reason: 'Nested map modification should not affect ${reasons[i]}');
+      expect(map3['k2'], 'old value 2', reason: 'Nested map modification should not affect ${reasons[i]}');
     }
   });
 
@@ -702,8 +648,7 @@ void main() {
     final snapshot2 = await reference2.get();
     expect(snapshot2.exists, false);
 
-    final snapshot =
-        await firestore.collection('users').document(document1Id).get();
+    final snapshot = await firestore.collection('users').document(document1Id).get();
     expect(snapshot['someField'], 'someValue');
 
     final querySnapshot = await firestore.collection('users').getDocuments();
@@ -715,8 +660,7 @@ void main() {
     final firestore = MockFirestoreInstance();
     // These documents are not saved
     final nonExistentId = 'salkdjfaarecikvdiko0';
-    final snapshot1 =
-        await firestore.collection('users').document(nonExistentId).get();
+    final snapshot1 = await firestore.collection('users').document(nonExistentId).get();
     expect(snapshot1, isNotNull);
     expect(snapshot1.documentID, nonExistentId);
     expect(snapshot1.data, isNull);
@@ -800,10 +744,7 @@ void main() {
     final bar = firestore.collection('users').document('bar');
     await foo.setData(<String, dynamic>{'name.firstName': 'Bar'});
 
-    await firestore
-        .collection('users')
-        .document()
-        .setData(<String, dynamic>{'name.firstName': 'Survivor'});
+    await firestore.collection('users').document().setData(<String, dynamic>{'name.firstName': 'Survivor'});
 
     final batch = firestore.batch();
     batch.delete(foo);
@@ -835,8 +776,7 @@ void main() {
     expect(() => firestore.document('users'), throwsA(isA<AssertionError>()));
 
     // subcollection
-    expect(() => firestore.document('users/1234/friends'),
-        throwsA(isA<AssertionError>()));
+    expect(() => firestore.document('users/1234/friends'), throwsA(isA<AssertionError>()));
   });
 
   test('MockFirestoreInstance.collection with an invalid path', () async {
@@ -844,11 +784,9 @@ void main() {
 
     // This should fail because users/1234 (2 segments) is a reference to a
     // document, not a collection.
-    expect(() => firestore.collection('users/1234'),
-        throwsA(isA<AssertionError>()));
+    expect(() => firestore.collection('users/1234'), throwsA(isA<AssertionError>()));
 
-    expect(() => firestore.collection('users/1234/friends/567'),
-        throwsA(isA<AssertionError>()));
+    expect(() => firestore.collection('users/1234/friends/567'), throwsA(isA<AssertionError>()));
   });
 
   test('Transaction set, update, and delete', () async {
@@ -878,8 +816,7 @@ void main() {
     expect(updatedSnapshotFoo.data['name'], 'Fooo');
 
     final updatedSnapshotBar = await bar.get();
-    final nestedDocument =
-        updatedSnapshotBar.data['nested'] as Map<String, dynamic>;
+    final nestedDocument = updatedSnapshotBar.data['nested'] as Map<String, dynamic>;
     expect(nestedDocument['field'], 123);
 
     final deletedSnapshotBaz = await baz.get();
@@ -930,11 +867,11 @@ void main() {
     await firestore.document('bar/bar_3').setData({'value': '3'});
     final querySnapshot = await firestore.collectionGroup('bar').getDocuments();
     expect(querySnapshot.documents, hasLength(3));
-    expect(querySnapshot.documents.first.documentID, 'bar_1');
-    expect(querySnapshot.documents.first.reference.path, 'foo/foo_1/bar/bar_1');
-    expect(querySnapshot.documents.first.data, {'value': '1'});
-    expect(querySnapshot.documents[1].data, {'value': '2'});
-    expect(querySnapshot.documents[2].data, {'value': '3'});
+    expect(querySnapshot.documents.first.documentID, 'bar_3');
+    expect(querySnapshot.documents.first.reference.path, 'bar/bar_3');
+    expect(querySnapshot.documents.first.data, {'value': '3'});
+    expect(querySnapshot.documents[1].data, {'value': '1'});
+    expect(querySnapshot.documents[2].data, {'value': '2'});
   });
 
   test('CollectionGroup snapshots', () async {
@@ -945,14 +882,12 @@ void main() {
     expect(
         firestore.collectionGroup('bar').snapshots(),
         emits(QuerySnapshotMatcher([
+          DocumentSnapshotMatcher('bar_3', {'value': '3'}),
           DocumentSnapshotMatcher('bar_1', {'value': '1'}),
           DocumentSnapshotMatcher('bar_2', {'value': '2'}),
-          DocumentSnapshotMatcher('bar_3', {'value': '3'}),
-          ])));
+        ])));
   });
-  test(
-      'A sub-collection and a document property with identical names can coexist',
-      () async {
+  test('A sub-collection and a document property with identical names can coexist', () async {
     final firestore = MockFirestoreInstance();
 
     // We add a document to a sub-collection. We obviously expect that document
@@ -964,11 +899,7 @@ void main() {
         .document('child-1')
         .setData({'gift': 'Princess dress'});
     expect(
-        firestore
-            .collection('santa-claus-todo')
-            .document('family-1')
-            .collection('children')
-            .snapshots(),
+        firestore.collection('santa-claus-todo').document('family-1').collection('children').snapshots(),
         emits(QuerySnapshotMatcher([
           DocumentSnapshotMatcher('child-1', {
             'gift': 'Princess dress',
@@ -978,10 +909,7 @@ void main() {
     // Now we set data for a document on the path to the document created
     // above. The new data has a property whose name is identical to the
     // sub-collection. They should not conflict and we can query both.
-    await firestore
-        .collection('santa-claus-todo')
-        .document('family-1')
-        .setData({'children': 3});
+    await firestore.collection('santa-claus-todo').document('family-1').setData({'children': 3});
     expect(
         firestore.collection('santa-claus-todo').snapshots(),
         emits(QuerySnapshotMatcher([
@@ -990,11 +918,7 @@ void main() {
           })
         ])));
     expect(
-        firestore
-            .collection('santa-claus-todo')
-            .document('family-1')
-            .collection('children')
-            .snapshots(),
+        firestore.collection('santa-claus-todo').document('family-1').collection('children').snapshots(),
         emits(QuerySnapshotMatcher([
           DocumentSnapshotMatcher('child-1', {
             'gift': 'Princess dress',

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -923,15 +923,31 @@ void main() {
     expect(eve.data['friends'], equals(['Alice', 'Bob'])); // nothing changed
   });
 
-  test('CollectionGroup', () async {
+  test('CollectionGroup getDocuments', () async {
     final firestore = MockFirestoreInstance();
     await firestore.document('foo/foo_1/bar/bar_1').setData({'value': '1'});
     await firestore.document('foo/foo_2/bar/bar_2').setData({'value': '2'});
     await firestore.document('bar/bar_3').setData({'value': '3'});
     final querySnapshot = await firestore.collectionGroup('bar').getDocuments();
     expect(querySnapshot.documents, hasLength(3));
+    expect(querySnapshot.documents.first.documentID, 'bar_1');
+    expect(querySnapshot.documents.first.reference.path, 'foo/foo_1/bar/bar_1');
     expect(querySnapshot.documents.first.data, {'value': '1'});
     expect(querySnapshot.documents[1].data, {'value': '2'});
     expect(querySnapshot.documents[2].data, {'value': '3'});
+  });
+
+  test('CollectionGroup snapshots', () async {
+    final firestore = MockFirestoreInstance();
+    await firestore.document('foo/foo_1/bar/bar_1').setData({'value': '1'});
+    await firestore.document('foo/foo_2/bar/bar_2').setData({'value': '2'});
+    await firestore.document('bar/bar_3').setData({'value': '3'});
+    expect(
+        firestore.collectionGroup('bar').snapshots(),
+        emits(QuerySnapshotMatcher([
+          DocumentSnapshotMatcher('bar_1', {'value': '1'}),
+          DocumentSnapshotMatcher('bar_2', {'value': '2'}),
+          DocumentSnapshotMatcher('bar_3', {'value': '3'}),
+        ])));
   });
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -922,4 +922,16 @@ void main() {
     expect(eve.data['name'], isNot('John')); // nothing changed
     expect(eve.data['friends'], equals(['Alice', 'Bob'])); // nothing changed
   });
+
+  test('CollectionGroup', () async {
+    final firestore = MockFirestoreInstance();
+    await firestore.document('foo/foo_1/bar/bar_1').setData({'value': '1'});
+    await firestore.document('foo/foo_2/bar/bar_2').setData({'value': '2'});
+    await firestore.document('bar/bar_3').setData({'value': '3'});
+    final querySnapshot = await firestore.collectionGroup('bar').getDocuments();
+    expect(querySnapshot.documents, hasLength(3));
+    expect(querySnapshot.documents.first.data, {'value': '1'});
+    expect(querySnapshot.documents[1].data, {'value': '2'});
+    expect(querySnapshot.documents[2].data, {'value': '3'});
+  });
 }

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -74,7 +74,8 @@ void main() {
       // act
       final docId = await collectionRef.add(data);
       // assert
-      final docSnap = await instance.collection('users').document(docId.documentID).get();
+      final docSnap =
+          await instance.collection('users').document(docId.documentID).get();
       expect(docSnap.data['username'], 'johndoe');
       expect(docSnap.data['joined'], isA<Timestamp>());
     });
@@ -95,7 +96,11 @@ void main() {
         .document('2')
         .setData({'label': 'relationship2'});
     expect(
-        firestore.collection('userProfiles').document('a').collection('relationship').snapshots(),
+        firestore
+            .collection('userProfiles')
+            .document('a')
+            .collection('relationship')
+            .snapshots(),
         emits(QuerySnapshotMatcher([
           DocumentSnapshotMatcher('1', {
             'label': 'relationship1',
@@ -141,22 +146,32 @@ void main() {
       expect(snap.documentChanges[0].newIndex, 0);
     }));
   });
-  test('Snapshots sets exists property to false if the document does not exist', () async {
+  test('Snapshots sets exists property to false if the document does not exist',
+      () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').document(uid).setData({
       'name': 'Bob',
     });
-    instance.collection('users').document('doesnotexist').snapshots().listen(expectAsync1((document) {
+    instance
+        .collection('users')
+        .document('doesnotexist')
+        .snapshots()
+        .listen(expectAsync1((document) {
       expect(document.exists, equals(false));
     }));
   });
 
-  test('Snapshots sets exists property to true if the document does  exist', () async {
+  test('Snapshots sets exists property to true if the document does  exist',
+      () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').document(uid).setData({
       'name': 'Bob',
     });
-    instance.collection('users').document(uid).snapshots().listen(expectAsync1((document) {
+    instance
+        .collection('users')
+        .document(uid)
+        .snapshots()
+        .listen(expectAsync1((document) {
       expect(document.exists, equals(true));
     }));
   });
@@ -172,7 +187,8 @@ void main() {
         .document('ccc');
 
     expect(documentReference.path, 'users/aaa/friends/bbb/friends-friends/ccc');
-    expect(documentReference.parent().path, 'users/aaa/friends/bbb/friends-friends');
+    expect(documentReference.parent().path,
+        'users/aaa/friends/bbb/friends-friends');
   });
 
   test('Document and collection parent()', () async {
@@ -194,7 +210,8 @@ void main() {
 
   test('firestore field', () async {
     final instance = MockFirestoreInstance();
-    final documentReference = instance.collection('users').document('aaa').collection('friends');
+    final documentReference =
+        instance.collection('users').document('aaa').collection('friends');
 
     expect(documentReference.firestore, instance);
     expect(documentReference.parent().firestore, instance);
@@ -202,7 +219,11 @@ void main() {
 
   test('Document reference equality', () async {
     final instance = MockFirestoreInstance();
-    final documentReference1 = instance.collection('users').document('aaa').collection('friends').document('xyz');
+    final documentReference1 = instance
+        .collection('users')
+        .document('aaa')
+        .collection('friends')
+        .document('xyz');
     final documentReference2 = instance.document('users/aaa/friends/xyz');
 
     expect(documentReference1, equals(documentReference2));
@@ -225,18 +246,28 @@ void main() {
   test('Saving documents in subcollection', () async {
     final instance = MockFirestoreInstance();
     // Creates 1st document in "users/abc/friends/<documentId>"
-    await instance.collection('users').document(uid).collection('friends').add(<String, dynamic>{'name': 'Foo'});
+    await instance
+        .collection('users')
+        .document(uid)
+        .collection('friends')
+        .add(<String, dynamic>{'name': 'Foo'});
 
     // The command above does not create a document at "users/abc"
-    final intermediateDocument = await instance.collection('users').document(uid).get();
+    final intermediateDocument =
+        await instance.collection('users').document(uid).get();
     expect(intermediateDocument.exists, false);
 
     // Gets a reference to an unsaved document.
     // This shouldn't appear in getDocuments
-    final documentReference = instance.collection('users').document(uid).collection('friends').document('xyz');
+    final documentReference = instance
+        .collection('users')
+        .document(uid)
+        .collection('friends')
+        .document('xyz');
     expect(documentReference.path, 'users/$uid/friends/xyz');
 
-    var subcollection = instance.collection('users').document(uid).collection('friends');
+    var subcollection =
+        instance.collection('users').document(uid).collection('friends');
     var querySnapshot = await subcollection.getDocuments();
     expect(querySnapshot.documents, hasLength(1));
 
@@ -245,7 +276,8 @@ void main() {
 
     // TODO: Remove the line below once MockQuery defers query execution.
     // https://github.com/atn832/cloud_firestore_mocks/issues/31
-    subcollection = instance.collection('users').document(uid).collection('friends');
+    subcollection =
+        instance.collection('users').document(uid).collection('friends');
     querySnapshot = await subcollection.getDocuments();
     expect(querySnapshot.documents, hasLength(2));
   });
@@ -260,7 +292,11 @@ void main() {
       }
     });
 
-    final documentReference = instance.collection('users').document(uid).collection('friends').document('xyz');
+    final documentReference = instance
+        .collection('users')
+        .document(uid)
+        .collection('friends')
+        .document('xyz');
 
     final snapshot = await documentReference.get();
     expect(snapshot.data['name'], 'Foo');
@@ -272,7 +308,8 @@ void main() {
     final nonExistentId = 'nonExistentId';
     final instance = MockFirestoreInstance();
 
-    final snapshot1 = await instance.collection('users').document(nonExistentId).get();
+    final snapshot1 =
+        await instance.collection('users').document(nonExistentId).get();
     expect(snapshot1, isNotNull);
     expect(snapshot1.documentID, nonExistentId);
     // data field should be null before the document is saved
@@ -329,7 +366,9 @@ void main() {
     test('FieldValue.delete() deletes key values', () async {
       final firestore = MockFirestoreInstance();
       await firestore.document('root/foo').setData({'flower': 'rose'});
-      await firestore.document('root/foo').setData({'flower': FieldValue.delete()});
+      await firestore
+          .document('root/foo')
+          .setData({'flower': FieldValue.delete()});
       final document = await firestore.document('root/foo').get();
       expect(document.data.isEmpty, equals(true));
     });
@@ -343,7 +382,8 @@ void main() {
       final bob = users.documents.first;
       expect(bob['created'], isNotNull);
       final bobCreated = bob['created'] as Timestamp; // Not DateTime
-      final timeDiff = Timestamp.now().millisecondsSinceEpoch - bobCreated.millisecondsSinceEpoch;
+      final timeDiff = Timestamp.now().millisecondsSinceEpoch -
+          bobCreated.millisecondsSinceEpoch;
       // Mock is fast it shouldn't take more than 1000 milliseconds to execute the code above
       expect(timeDiff, lessThan(1000));
     });
@@ -435,7 +475,8 @@ void main() {
 
     test('FieldValue in nested objects', () async {
       final firestore = MockFirestoreInstance();
-      final docRef = firestore.collection('MyCollection').document('MyDocument');
+      final docRef =
+          firestore.collection('MyCollection').document('MyDocument');
       final batch = firestore.batch();
 
       batch.setData(
@@ -467,24 +508,28 @@ void main() {
 
   test('setData to nested documents', () async {
     final instance = MockFirestoreInstance();
-    await instance
-        .collection('users')
-        .document(uid)
-        .setData({'foo.bar.baz.username': 'SomeName', 'foo.bar.created': FieldValue.serverTimestamp()});
+    await instance.collection('users').document(uid).setData({
+      'foo.bar.baz.username': 'SomeName',
+      'foo.bar.created': FieldValue.serverTimestamp()
+    });
 
     final snapshot = await instance.collection('users').getDocuments();
     expect(snapshot.documents.length, equals(1));
     final topLevelDocument = snapshot.documents.first;
     expect(topLevelDocument['foo'], isNotNull);
-    final secondLevelDocument = topLevelDocument['foo'] as Map<dynamic, dynamic>;
+    final secondLevelDocument =
+        topLevelDocument['foo'] as Map<dynamic, dynamic>;
     expect(secondLevelDocument['bar'], isNotNull);
-    final thirdLevelDocument = secondLevelDocument['bar'] as Map<dynamic, dynamic>;
+    final thirdLevelDocument =
+        secondLevelDocument['bar'] as Map<dynamic, dynamic>;
     expect(thirdLevelDocument['baz'], isNotNull);
-    final fourthLevelDocument = thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
+    final fourthLevelDocument =
+        thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
     expect(fourthLevelDocument['username'], 'SomeName');
 
     final barCreated = thirdLevelDocument['created'] as Timestamp;
-    final timeDiff = Timestamp.now().millisecondsSinceEpoch - barCreated.millisecondsSinceEpoch;
+    final timeDiff = Timestamp.now().millisecondsSinceEpoch -
+        barCreated.millisecondsSinceEpoch;
     // Mock is fast it shouldn't take more than 1000 milliseconds to execute the code above
     expect(timeDiff, lessThan(1000));
   });
@@ -505,11 +550,14 @@ void main() {
     expect(snapshot.documents.length, equals(1));
     final topLevelDocument = snapshot.documents.first;
     expect(topLevelDocument['foo'], isNotNull);
-    final secondLevelDocument = topLevelDocument['foo'] as Map<dynamic, dynamic>;
+    final secondLevelDocument =
+        topLevelDocument['foo'] as Map<dynamic, dynamic>;
     expect(secondLevelDocument['bar'], isNotNull);
-    final thirdLevelDocument = secondLevelDocument['bar'] as Map<dynamic, dynamic>;
+    final thirdLevelDocument =
+        secondLevelDocument['bar'] as Map<dynamic, dynamic>;
     expect(thirdLevelDocument['baz'], isNotNull);
-    final fourthLevelDocument = thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
+    final fourthLevelDocument =
+        thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
     expect(fourthLevelDocument['username'], 'SomeName');
 
     // UpdateData should create the expected object
@@ -517,11 +565,14 @@ void main() {
     expect(snapshot2.documents.length, equals(1));
     final topLevelDocument2 = snapshot2.documents.first;
     expect(topLevelDocument2['foo'], isNotNull);
-    final secondLevelDocument2 = topLevelDocument2['foo'] as Map<dynamic, dynamic>;
+    final secondLevelDocument2 =
+        topLevelDocument2['foo'] as Map<dynamic, dynamic>;
     expect(secondLevelDocument2['bar'], isNotNull);
-    final thirdLevelDocument2 = secondLevelDocument2['bar'] as Map<dynamic, dynamic>;
+    final thirdLevelDocument2 =
+        secondLevelDocument2['bar'] as Map<dynamic, dynamic>;
     expect(thirdLevelDocument2['BAZ'], isNotNull);
-    final fourthLevelDocument2 = thirdLevelDocument2['BAZ'] as Map<dynamic, dynamic>;
+    final fourthLevelDocument2 =
+        thirdLevelDocument2['BAZ'] as Map<dynamic, dynamic>;
     expect(fourthLevelDocument2['username'], 'AnotherName');
   });
 
@@ -622,13 +673,16 @@ void main() {
           }
         }
       ];
-      expect(result.data['array'], expected, reason: 'Array modification should not affect ${reasons[i]}');
+      expect(result.data['array'], expected,
+          reason: 'Array modification should not affect ${reasons[i]}');
 
       final map1 = result.data['map'] as Map<String, dynamic>;
-      expect(map1['k1'], 'old value 1', reason: 'Map modification should not affect ${reasons[i]}');
+      expect(map1['k1'], 'old value 1',
+          reason: 'Map modification should not affect ${reasons[i]}');
       final map2 = map1['nested1'] as Map<String, dynamic>;
       final map3 = map2['nested2'] as Map<String, dynamic>;
-      expect(map3['k2'], 'old value 2', reason: 'Nested map modification should not affect ${reasons[i]}');
+      expect(map3['k2'], 'old value 2',
+          reason: 'Nested map modification should not affect ${reasons[i]}');
     }
   });
 
@@ -648,7 +702,8 @@ void main() {
     final snapshot2 = await reference2.get();
     expect(snapshot2.exists, false);
 
-    final snapshot = await firestore.collection('users').document(document1Id).get();
+    final snapshot =
+        await firestore.collection('users').document(document1Id).get();
     expect(snapshot['someField'], 'someValue');
 
     final querySnapshot = await firestore.collection('users').getDocuments();
@@ -660,7 +715,8 @@ void main() {
     final firestore = MockFirestoreInstance();
     // These documents are not saved
     final nonExistentId = 'salkdjfaarecikvdiko0';
-    final snapshot1 = await firestore.collection('users').document(nonExistentId).get();
+    final snapshot1 =
+        await firestore.collection('users').document(nonExistentId).get();
     expect(snapshot1, isNotNull);
     expect(snapshot1.documentID, nonExistentId);
     expect(snapshot1.data, isNull);
@@ -744,7 +800,10 @@ void main() {
     final bar = firestore.collection('users').document('bar');
     await foo.setData(<String, dynamic>{'name.firstName': 'Bar'});
 
-    await firestore.collection('users').document().setData(<String, dynamic>{'name.firstName': 'Survivor'});
+    await firestore
+        .collection('users')
+        .document()
+        .setData(<String, dynamic>{'name.firstName': 'Survivor'});
 
     final batch = firestore.batch();
     batch.delete(foo);
@@ -776,7 +835,8 @@ void main() {
     expect(() => firestore.document('users'), throwsA(isA<AssertionError>()));
 
     // subcollection
-    expect(() => firestore.document('users/1234/friends'), throwsA(isA<AssertionError>()));
+    expect(() => firestore.document('users/1234/friends'),
+        throwsA(isA<AssertionError>()));
   });
 
   test('MockFirestoreInstance.collection with an invalid path', () async {
@@ -784,9 +844,11 @@ void main() {
 
     // This should fail because users/1234 (2 segments) is a reference to a
     // document, not a collection.
-    expect(() => firestore.collection('users/1234'), throwsA(isA<AssertionError>()));
+    expect(() => firestore.collection('users/1234'),
+        throwsA(isA<AssertionError>()));
 
-    expect(() => firestore.collection('users/1234/friends/567'), throwsA(isA<AssertionError>()));
+    expect(() => firestore.collection('users/1234/friends/567'),
+        throwsA(isA<AssertionError>()));
   });
 
   test('Transaction set, update, and delete', () async {
@@ -816,7 +878,8 @@ void main() {
     expect(updatedSnapshotFoo.data['name'], 'Fooo');
 
     final updatedSnapshotBar = await bar.get();
-    final nestedDocument = updatedSnapshotBar.data['nested'] as Map<String, dynamic>;
+    final nestedDocument =
+        updatedSnapshotBar.data['nested'] as Map<String, dynamic>;
     expect(nestedDocument['field'], 123);
 
     final deletedSnapshotBaz = await baz.get();
@@ -887,7 +950,9 @@ void main() {
           DocumentSnapshotMatcher('bar_2', {'value': '2'}),
         ])));
   });
-  test('A sub-collection and a document property with identical names can coexist', () async {
+  test(
+      'A sub-collection and a document property with identical names can coexist',
+      () async {
     final firestore = MockFirestoreInstance();
 
     // We add a document to a sub-collection. We obviously expect that document
@@ -899,7 +964,11 @@ void main() {
         .document('child-1')
         .setData({'gift': 'Princess dress'});
     expect(
-        firestore.collection('santa-claus-todo').document('family-1').collection('children').snapshots(),
+        firestore
+            .collection('santa-claus-todo')
+            .document('family-1')
+            .collection('children')
+            .snapshots(),
         emits(QuerySnapshotMatcher([
           DocumentSnapshotMatcher('child-1', {
             'gift': 'Princess dress',
@@ -909,7 +978,10 @@ void main() {
     // Now we set data for a document on the path to the document created
     // above. The new data has a property whose name is identical to the
     // sub-collection. They should not conflict and we can query both.
-    await firestore.collection('santa-claus-todo').document('family-1').setData({'children': 3});
+    await firestore
+        .collection('santa-claus-todo')
+        .document('family-1')
+        .setData({'children': 3});
     expect(
         firestore.collection('santa-claus-todo').snapshots(),
         emits(QuerySnapshotMatcher([
@@ -918,7 +990,11 @@ void main() {
           })
         ])));
     expect(
-        firestore.collection('santa-claus-todo').document('family-1').collection('children').snapshots(),
+        firestore
+            .collection('santa-claus-todo')
+            .document('family-1')
+            .collection('children')
+            .snapshots(),
         emits(QuerySnapshotMatcher([
           DocumentSnapshotMatcher('child-1', {
             'gift': 'Princess dress',

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore_mocks/src/util.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('buildSubpathForCollectionGroup', () {
+    final root = <String, dynamic>{
+      'foo': {
+        'foo_1': {
+          'bar': {
+            'bar_1': {'value': '1'}
+          }
+        },
+        'foo_2': {
+          'bar': {
+            'bar_2': {'value': '2'}
+          }
+        }
+      },
+      'bar': {
+        'bar_3': {'value': '3'}
+      },
+      'baz': {
+        'baz_1': {'hello': 'world'}
+      }
+    };
+    const collectionId = 'bar';
+    final result = <String, dynamic>{};
+    buildSubpathForCollectionGroup(root, root, collectionId, result);
+    // result has only paths which contain "bar"
+    expect(result, root..remove('baz'));
+  });
+}

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -24,8 +24,7 @@ void main() {
       }
     };
     const collectionId = 'bar';
-    final result = <String, dynamic>{};
-    buildTreeIncludingCollectionId(root, root, collectionId, result);
+    final result = buildTreeIncludingCollectionId(root, root, collectionId, {});
     // result has only paths which contain "bar"
     expect(result, root..remove('baz'));
   });

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -2,7 +2,7 @@ import 'package:cloud_firestore_mocks/src/util.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('buildSubpathForCollectionGroup', () {
+  test('buildTreeIncludingCollectionId', () {
     final root = <String, dynamic>{
       'foo': {
         'foo_1': {
@@ -25,7 +25,7 @@ void main() {
     };
     const collectionId = 'bar';
     final result = <String, dynamic>{};
-    buildSubpathForCollectionGroup(root, root, collectionId, result);
+    buildTreeIncludingCollectionId(root, root, collectionId, result);
     // result has only paths which contain "bar"
     expect(result, root..remove('baz'));
   });


### PR DESCRIPTION
## Overview
solve https://github.com/atn832/cloud_firestore_mocks/issues/107
support [CollectionGroup Query](https://firebase.google.com/docs/firestore/query-data/queries#collection-group-query)

## Review Points
* add `isCollectionGroup` flag on MockCollectionReference in imitaion of [Firestore offical plugin implementation](https://github.com/FirebaseExtended/flutterfire/search?q=isCollectionGroup&type=)
  * Especially, I would like you to review 2 points.
    * `getSubpath()` returns _all paths which contain "collectionId"_
    * By solving path of DocumentReference In `getDocuments()`, DocumentReference also works expectedly.
