### PR TITLE
Use different namespace for collections and documents' data

### DIFF
--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -14,6 +14,7 @@ import 'util.dart';
 
 class MockFirestoreInstance extends Mock implements Firestore {
   final _root = <String, dynamic>{};
+  final _docsData = <String, dynamic>{};
   final _snapshotStreamControllerRoot = <String, dynamic>{};
 
   /// Saved documents' full paths from root. For example:
@@ -29,7 +30,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
     assert(segments.length % 2 == 1,
         'Invalid document reference. Collection references must have an odd number of segments');
     return MockCollectionReference(this, path, getSubpath(_root, path),
-        getSubpath(_snapshotStreamControllerRoot, path));
+        _docsData, getSubpath(_snapshotStreamControllerRoot, path));
   }
 
   @override
@@ -46,6 +47,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
         path,
         documentId,
         getSubpath(_root, path),
+        _docsData,
         _root,
         getSubpath(_snapshotStreamControllerRoot, path));
   }
@@ -106,8 +108,26 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   String dump() {
+    final copy = deepCopy(_root);
+
+    // `copy` only contains the categories and sub-categories at this point,
+    // no document data. This loop adds each document to the tree.
+    for (var doc in _docsData.entries) {
+      final docId = doc.key;
+      final docProperties = doc.value;
+      final docCopy = getSubpath(copy, docId);
+      for (var property in docProperties.entries) {
+        // In case there is a conflict between a sub-category name and document
+        // property, the sub-category takes precedence, meaning the returned
+        // json will not return that document property.
+        if (!docCopy.containsKey(property.key)) {
+          docCopy[property.key] = property.value;
+        }
+      }
+    }
+
     final encoder = JsonEncoder.withIndent('  ', myEncode);
-    final jsonText = encoder.convert(_root);
+    final jsonText = encoder.convert(copy);
     return jsonText;
   }
 

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -922,4 +922,56 @@ void main() {
     expect(eve.data['name'], isNot('John')); // nothing changed
     expect(eve.data['friends'], equals(['Alice', 'Bob'])); // nothing changed
   });
+
+  test(
+      'A sub-collection and a document property with identical names can coexist',
+      () async {
+    final firestore = MockFirestoreInstance();
+
+    // We add a document to a sub-collection. We obviously expect that document
+    // to exist, even though intermediate documents/collections don't.
+    await firestore
+        .collection('santa-claus-todo')
+        .document('family-1')
+        .collection('children')
+        .document('child-1')
+        .setData({'gift': 'Princess dress'});
+    expect(
+        firestore
+            .collection('santa-claus-todo')
+            .document('family-1')
+            .collection('children')
+            .snapshots(),
+        emits(QuerySnapshotMatcher([
+          DocumentSnapshotMatcher('child-1', {
+            'gift': 'Princess dress',
+          })
+        ])));
+
+    // Now we set data for a document on the path to the document created
+    // above. The new data has a property whose name is identical to the
+    // sub-collection. They should not conflict and we can query both.
+    await firestore
+        .collection('santa-claus-todo')
+        .document('family-1')
+        .setData({'children': 3});
+    expect(
+        firestore.collection('santa-claus-todo').snapshots(),
+        emits(QuerySnapshotMatcher([
+          DocumentSnapshotMatcher('family-1', {
+            'children': 3,
+          })
+        ])));
+    expect(
+        firestore
+            .collection('santa-claus-todo')
+            .document('family-1')
+            .collection('children')
+            .snapshots(),
+        emits(QuerySnapshotMatcher([
+          DocumentSnapshotMatcher('child-1', {
+            'gift': 'Princess dress',
+          })
+        ])));
+  });
 }


### PR DESCRIPTION
A document may contain a key and a sub-collection with the same name: they should not conflict.

By having separate namespaces for data and sub-collections, this also fixes #90: indeed, updating a document's data without setting the merge flag won't remove sub-collections.

One limitation is the `dump()` function of the `MockFirestoreInstance` class: because it rerturns a single tree, precedence is given to the sub-collection is there is a name conflict between a sub-collection and a key in the data.

Fixes #90.