### PR TITLE
[Migration] support cloud_firestore 0.14.x

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -8,7 +8,17 @@ on:
       - master
 
 jobs:
-  test:
+  package-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v1
+      - run: flutter test
+  example-test:
+    defaults:
+      run:
+        working-directory: example
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -17,22 +17,17 @@ example/android/.settings/
 example/android/local.properties
 
 # These files are marked not to check in version control
-example/ios/.symlinks
-example/ios/Flutter/flutter_export_environment.sh
-example/ios/Flutter/Flutter.framework
-example/ios/Flutter/Flutter.podspec
-example/ios/Flutter/Generated.xcconfig
-example/ios/Pods
-example/ios/Podfile.lock
-ios/.symlinks
-ios/Flutter/flutter_export_environment.sh
-ios/Flutter/App.framework/
-ios/Flutter/Flutter.framework
-ios/Flutter/Flutter.podspec
-ios/Flutter/Generated.xcconfig
-ios/Pods
-ios/Podfile.lock
-ios/Runner.xcworkspace/xcuserdata/
+**/ios/.symlinks
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/Flutter/App.framework
+**/ios/Flutter/.last_build_id
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Pods
+**/ios/Podfile.lock
+**/ios/Runner.xcworkspace/xcuserdata/
+
 android/.gradle/
 
 *.log

--- a/example/README.md
+++ b/example/README.md
@@ -6,3 +6,8 @@ The example project comes from
 https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore/example,
 to which I've implemented two unit tests. See
 https://github.com/atn832/cloud_firestore_mocks/blob/master/example/test/widget_test.dart.
+
+## driver_test
+```sh
+flutter driver --driver=test_driver/cloud_firestore_test.dart
+```

--- a/example/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/example/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -1,8 +1,8 @@
 package io.flutter.plugins;
 
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugins.firebase.cloudfirestore.CloudFirestorePlugin;
-import io.flutter.plugins.firebase.core.FirebaseCorePlugin;
+import io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin;
+import io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin;
 
 /**
  * Generated file. Do not edit.
@@ -12,8 +12,8 @@ public final class GeneratedPluginRegistrant {
     if (alreadyRegisteredWith(registry)) {
       return;
     }
-    CloudFirestorePlugin.registerWith(registry.registrarFor("io.flutter.plugins.firebase.cloudfirestore.CloudFirestorePlugin"));
-    FirebaseCorePlugin.registerWith(registry.registrarFor("io.flutter.plugins.firebase.core.FirebaseCorePlugin"));
+    FlutterFirebaseFirestorePlugin.registerWith(registry.registrarFor("io.flutter.plugins.firebase.firestore.FlutterFirebaseFirestorePlugin"));
+    FlutterFirebaseCorePlugin.registerWith(registry.registrarFor("io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin"));
   }
 
   private static boolean alreadyRegisteredWith(PluginRegistry registry) {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.3.0'
+        classpath 'com.google.gms:google-services:4.3.3'
     }
 }
 

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -8,12 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		3B80C3941E831B6300D905FE /* App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; };
-		3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B80C3931E831B6300D905FE /* App.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C6F5A711EC3CCCC008D64B5 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 5C6F5A701EC3CCCC008D64B5 /* GeneratedPluginRegistrant.m */; };
 		7A1ECC911E8EDB6900309407 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7A1ECC901E8EDB6900309407 /* GoogleService-Info.plist */; };
-		9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; };
-		9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9740EEBA1CF902C7004384FC /* Flutter.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB21CF90195004384FC /* Debug.xcconfig */; };
 		9740EEB51CF90195004384FC /* Generated.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB31CF90195004384FC /* Generated.xcconfig */; };
 		978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */; };
@@ -31,8 +27,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				3B80C3951E831B6300D905FE /* App.framework in Embed Frameworks */,
-				9705A1C71CF904A300538489 /* Flutter.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -41,7 +35,6 @@
 
 /* Begin PBXFileReference section */
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		3B80C3931E831B6300D905FE /* App.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = App.framework; path = Flutter/App.framework; sourceTree = "<group>"; };
 		5C6F5A6F1EC3CCCC008D64B5 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		5C6F5A701EC3CCCC008D64B5 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		64D7CC71DA6013C628EE84F1 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -51,7 +44,6 @@
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
-		9740EEBA1CF902C7004384FC /* Flutter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Flutter.framework; path = Flutter/Flutter.framework; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		97C146F21CF9000F007C117D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -67,8 +59,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9705A1C61CF904A100538489 /* Flutter.framework in Frameworks */,
-				3B80C3941E831B6300D905FE /* App.framework in Frameworks */,
 				CE57DC9C9240FBD15E358E24 /* libPods-Runner.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -88,9 +78,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
-				3B80C3931E831B6300D905FE /* App.framework */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
-				9740EEBA1CF902C7004384FC /* Flutter.framework */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
@@ -238,7 +226,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" thin";
+			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
 		532EA9D341340B1DCD08293D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -339,7 +327,6 @@
 /* Begin XCBuildConfiguration section */
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -387,7 +374,6 @@
 		};
 		97C147041CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/example/ios/Runner/GeneratedPluginRegistrant.m
+++ b/example/ios/Runner/GeneratedPluginRegistrant.m
@@ -4,8 +4,8 @@
 
 #import "GeneratedPluginRegistrant.h"
 
-#if __has_include(<cloud_firestore/FLTCloudFirestorePlugin.h>)
-#import <cloud_firestore/FLTCloudFirestorePlugin.h>
+#if __has_include(<cloud_firestore/FLTFirebaseFirestorePlugin.h>)
+#import <cloud_firestore/FLTFirebaseFirestorePlugin.h>
 #else
 @import cloud_firestore;
 #endif
@@ -19,7 +19,7 @@
 @implementation GeneratedPluginRegistrant
 
 + (void)registerWithRegistry:(NSObject<FlutterPluginRegistry>*)registry {
-  [FLTCloudFirestorePlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTCloudFirestorePlugin"]];
+  [FLTFirebaseFirestorePlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTFirebaseFirestorePlugin"]];
   [FLTFirebaseCorePlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTFirebaseCorePlugin"]];
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,23 +4,22 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
-import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  final app = await FirebaseApp.configure(
+  final app = await Firebase.initializeApp(
     name: 'test',
     options: const FirebaseOptions(
-      googleAppID: '1:79601577497:ios:5f2bcc6ba8cecddd',
-      gcmSenderID: '79601577497',
+      appId: '1:79601577497:ios:5f2bcc6ba8cecddd',
+      messagingSenderId: '79601577497',
       apiKey: 'AIzaSyArgmRGfB5kiQT6CunAOmKRVKEsxKmy6YI-G72PVU',
-      projectID: 'flutter-firestore',
+      projectId: 'flutter-firestore',
     ),
   );
-  final firestore = Firestore(app: app);
-  await firestore.settings();
+  final firestore = FirebaseFirestore.instanceFor(app: app);
 
   runApp(MaterialApp(
       title: 'Firestore Example', home: MyHomePage(firestore: firestore)));
@@ -29,7 +28,7 @@ Future<void> main() async {
 class MessageList extends StatelessWidget {
   MessageList({this.firestore});
 
-  final Firestore firestore;
+  final FirebaseFirestore firestore;
 
   @override
   Widget build(BuildContext context) {
@@ -37,12 +36,12 @@ class MessageList extends StatelessWidget {
       stream: firestore.collection('messages').snapshots(),
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (!snapshot.hasData) return const Text('Loading...');
-        final messageCount = snapshot.data.documents.length;
+        final messageCount = snapshot.data.docs.length;
         return ListView.builder(
           itemCount: messageCount,
           itemBuilder: (_, int index) {
-            final document = snapshot.data.documents[index];
-            final dynamic message = document['message'];
+            final document = snapshot.data.docs[index];
+            final dynamic message = document.get('message');
             return ListTile(
               title: Text(
                 message != null ? message.toString() : '<No message retrieved>',
@@ -59,7 +58,7 @@ class MessageList extends StatelessWidget {
 class MyHomePage extends StatelessWidget {
   MyHomePage({this.firestore});
 
-  final Firestore firestore;
+  final FirebaseFirestore firestore;
 
   CollectionReference get messages => firestore.collection('messages');
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -7,8 +7,10 @@ import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_driver/driver_extension.dart';
 
 Future<void> main() async {
+  enableFlutterDriverExtension();
   WidgetsFlutterBinding.ensureInitialized();
   final app = await Firebase.initializeApp(
     name: 'test',

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,8 +4,8 @@ description: Demonstrates how to use the cloud_firestore_mocks plugin.
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^0.13.7
-  firebase_core: ^0.4.5
+  cloud_firestore: ^0.14.0+2
+  firebase_core: ^0.5.0
 
 dev_dependencies:
   flutter_driver:

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -73,7 +73,7 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
 
   @override
   Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler,
-      {Duration timeout = const Duration(seconds: 5)}) async {
+      {Duration timeout = const Duration(seconds: 30)}) async {
     Transaction transaction = _DummyTransaction();
     final handlerResult = await transactionHandler(transaction);
 

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -12,7 +12,7 @@ import 'mock_field_value_factory_platform.dart';
 import 'mock_write_batch.dart';
 import 'util.dart';
 
-class MockFirestoreInstance extends Mock implements Firestore {
+class MockFirestoreInstance extends Mock implements FirebaseFirestore {
   final _root = <String, dynamic>{};
   final _docsData = <String, dynamic>{};
   final _snapshotStreamControllerRoot = <String, dynamic>{};
@@ -48,7 +48,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   @override
-  DocumentReference document(String path) {
+  DocumentReference doc(String path) {
     final segments = path.split('/');
     // The actual behavior of Firestore for an invalid number of segments
     // differs by platforms. This library imitates it with assert.
@@ -72,8 +72,7 @@ class MockFirestoreInstance extends Mock implements Firestore {
   }
 
   @override
-  Future<Map<String, dynamic>> runTransaction(
-      TransactionHandler transactionHandler,
+  Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler,
       {Duration timeout = const Duration(seconds: 5)}) async {
     Transaction transaction = _DummyTransaction();
     final handlerResult = await transactionHandler(transaction);
@@ -180,22 +179,26 @@ class _DummyTransaction implements Transaction {
   }
 
   @override
-  Future<void> delete(DocumentReference documentReference) {
+  Transaction delete(DocumentReference documentReference) {
     _foundWrite = true;
-    return documentReference.delete();
+    documentReference.delete();
+    return _DummyTransaction();
   }
 
   @override
-  Future<void> update(
+  Transaction update(
       DocumentReference documentReference, Map<String, dynamic> data) {
     _foundWrite = true;
-    return documentReference.updateData(data);
+    documentReference.update(data);
+    return _DummyTransaction();
   }
 
   @override
-  Future<void> set(
-      DocumentReference documentReference, Map<String, dynamic> data) {
+  Transaction set(
+      DocumentReference documentReference, Map<String, dynamic> data,
+      [SetOptions options]) {
     _foundWrite = true;
-    return documentReference.setData(data);
+    documentReference.set(data);
+    return _DummyTransaction();
   }
 }

--- a/lib/src/mock_document_change.dart
+++ b/lib/src/mock_document_change.dart
@@ -25,5 +25,5 @@ class MockDocumentChange extends Mock implements DocumentChange {
   int get newIndex => _newIndex;
 
   @override
-  DocumentSnapshot get document => _document;
+  DocumentSnapshot get doc => _document;
 }

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -6,25 +6,23 @@ import 'package:mockito/mockito.dart';
 import 'util.dart';
 
 class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
-  final String _documentId;
+  final String _id;
   final Map<String, dynamic> _document;
   final bool _exists;
   final MockDocumentReference _reference;
 
-  MockDocumentSnapshot(this._reference, this._documentId,
-      Map<String, dynamic> document, this._exists)
+  MockDocumentSnapshot(
+      this._reference, this._id, Map<String, dynamic> document, this._exists)
       : _document = deepCopy(document);
 
   @override
-  String get documentID => _documentId;
+  String get id => _id;
 
   @override
-  dynamic operator [](String key) {
-    return _document[key];
-  }
+  dynamic get(dynamic key) => _document[key];
 
   @override
-  Map<String, dynamic> get data {
+  Map<String, dynamic> data() {
     if (_exists) {
       return deepCopy(_document);
     } else {

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -1,0 +1,11 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_firestore_mocks/src/mock_document_reference.dart';
+
+import 'mock_document_snapshot.dart';
+
+class MockQueryDocumentSnapshot extends MockDocumentSnapshot
+    implements QueryDocumentSnapshot {
+  MockQueryDocumentSnapshot(MockDocumentReference reference, String documentId,
+      Map<String, dynamic> document)
+      : super(reference, documentId, document, true);
+}

--- a/lib/src/mock_snapshot.dart
+++ b/lib/src/mock_snapshot.dart
@@ -2,13 +2,15 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_mocks/src/mock_document_change.dart';
 import 'package:mockito/mockito.dart';
 
+import 'mock_query_document_snapshot.dart';
+
 class MockSnapshot extends Mock implements QuerySnapshot {
   final List<DocumentSnapshot> _documents;
 
   final List<DocumentChange> _documentChanges = <DocumentChange>[];
 
   MockSnapshot(this._documents) {
-    // TODO: support another change tyep (removed, modified).
+    // TODO: support another change type (removed, modified).
     // ref: https://pub.dev/documentation/cloud_firestore_platform_interface/latest/cloud_firestore_platform_interface/DocumentChangeType-class.html
     _documents.asMap().forEach((index, document) {
       _documentChanges.add(MockDocumentChange(
@@ -22,8 +24,12 @@ class MockSnapshot extends Mock implements QuerySnapshot {
   }
 
   @override
-  List<DocumentSnapshot> get documents => _documents;
+  List<QueryDocumentSnapshot> get docs => _documents
+      .map(
+        (doc) => MockQueryDocumentSnapshot(doc.reference, doc.id, doc.data()),
+      )
+      .toList();
 
   @override
-  List<DocumentChange> get documentChanges => _documentChanges;
+  List<DocumentChange> get docChanges => _documentChanges;
 }

--- a/lib/src/mock_write_batch.dart
+++ b/lib/src/mock_write_batch.dart
@@ -7,17 +7,17 @@ class MockWriteBatch extends Mock implements WriteBatch {
   List<WriteTask> tasks = [];
 
   @override
-  void setData(DocumentReference document, Map<String, dynamic> data,
-      {bool merge = false}) {
+  void set(DocumentReference document, Map<String, dynamic> data,
+      [SetOptions setOptions]) {
     tasks.add(WriteTask()
       ..command = WriteCommand.setData
       ..document = document
       ..data = data
-      ..merge = merge);
+      ..merge = setOptions?.merge);
   }
 
   @override
-  void updateData(DocumentReference document, Map<String, dynamic> data) {
+  void update(DocumentReference document, Map<String, dynamic> data) {
     tasks.add(WriteTask()
       ..command = WriteCommand.updateData
       ..document = document
@@ -36,10 +36,14 @@ class MockWriteBatch extends Mock implements WriteBatch {
     for (final task in tasks) {
       switch (task.command) {
         case WriteCommand.setData:
-          task.document.setData(task.data, merge: task.merge);
+          if (task.merge != null) {
+            task.document.set(task.data, SetOptions(merge: task.merge));
+          } else {
+            task.document.set(task.data);
+          }
           break;
         case WriteCommand.updateData:
-          task.document.updateData(task.data);
+          task.document.update(task.data);
           break;
         case WriteCommand.delete:
           task.document.delete();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^0.13.7
-  cloud_firestore_platform_interface: ^1.1.2
+  cloud_firestore: ^0.14.0+2
+  cloud_firestore_platform_interface: ^2.0.1
   collection: ^1.14.13
   plugin_platform_interface: ^1.0.2
   mockito: ^4.1.1

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -135,11 +135,11 @@ void main() {
   });
   test('Snapshots returns a Stream of Snapshot changes', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').doc(uid).set({
-      'name': 'Bob',
-    });
+    const data = {'name': 'Bob'};
+    await instance.collection('users').doc(uid).set(data);
     instance.collection('users').snapshots().listen(expectAsync1((snap) {
       expect(snap.docChanges.length, 1);
+      expect(snap.docChanges.first.doc.data(), data);
       expect(snap.docChanges[0].type, DocumentChangeType.added);
       expect(snap.docChanges[0].oldIndex, -1);
       expect(snap.docChanges[0].newIndex, 0);

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -6,7 +6,11 @@ import 'package:test/test.dart';
 import 'document_snapshot_matcher.dart';
 import 'query_snapshot_matcher.dart';
 
-const expectedDumpAfterSetData = '''{
+const uid = 'abc';
+
+void main() {
+  group('MockFirestoreInstance.dump', () {
+    const expectedDumpAfterset = '''{
   "users": {
     "abc": {
       "name": "Bob"
@@ -14,16 +18,12 @@ const expectedDumpAfterSetData = '''{
   }
 }''';
 
-const uid = 'abc';
-
-void main() {
-  group('MockFirestoreInstance.dump', () {
     test('Sets data for a document within a collection', () async {
       final instance = MockFirestoreInstance();
-      await instance.collection('users').document(uid).setData({
+      await instance.collection('users').doc(uid).set({
         'name': 'Bob',
       });
-      expect(instance.dump(), equals(expectedDumpAfterSetData));
+      expect(instance.dump(), equals(expectedDumpAfterset));
     });
     test('Add adds data', () async {
       final instance = MockFirestoreInstance();
@@ -31,10 +31,10 @@ void main() {
         'content': 'hello!',
         'uid': uid,
       });
-      expect(doc1.documentID.length, greaterThanOrEqualTo(20));
+      expect(doc1.id.length, greaterThanOrEqualTo(20));
       expect(instance.dump(), equals('''{
   "messages": {
-    "${doc1.documentID}": {
+    "${doc1.id}": {
       "content": "hello!",
       "uid": "abc"
     }
@@ -46,11 +46,11 @@ void main() {
       });
       expect(instance.dump(), equals('''{
   "messages": {
-    "${doc1.documentID}": {
+    "${doc1.id}": {
       "content": "hello!",
       "uid": "abc"
     },
-    "${doc2.documentID}": {
+    "${doc2.id}": {
       "content": "there!",
       "uid": "abc"
     }
@@ -74,31 +74,30 @@ void main() {
       // act
       final docId = await collectionRef.add(data);
       // assert
-      final docSnap =
-          await instance.collection('users').document(docId.documentID).get();
-      expect(docSnap.data['username'], 'johndoe');
-      expect(docSnap.data['joined'], isA<Timestamp>());
+      final docSnap = await instance.collection('users').doc(docId.id).get();
+      expect(docSnap.get('username'), 'johndoe');
+      expect(docSnap.get('joined'), isA<Timestamp>());
     });
   });
 
-  test('nested calls to setData work', () async {
+  test('nested calls to set work', () async {
     final firestore = MockFirestoreInstance();
     await firestore
         .collection('userProfiles')
-        .document('a')
+        .doc('a')
         .collection('relationship')
-        .document('1')
-        .setData({'label': 'relationship1'});
+        .doc('1')
+        .set({'label': 'relationship1'});
     await firestore
         .collection('userProfiles')
-        .document('a')
+        .doc('a')
         .collection('relationship')
-        .document('2')
-        .setData({'label': 'relationship2'});
+        .doc('2')
+        .set({'label': 'relationship2'});
     expect(
         firestore
             .collection('userProfiles')
-            .document('a')
+            .doc('a')
             .collection('relationship')
             .snapshots(),
         emits(QuerySnapshotMatcher([
@@ -112,7 +111,7 @@ void main() {
   });
   test('Snapshots returns a Stream of Snapshots', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
     expect(
@@ -125,36 +124,36 @@ void main() {
   });
   test('Snapshots returns a Stream of Snapshot', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
     expect(
-        instance.collection('users').document(uid).snapshots(),
+        instance.collection('users').doc(uid).snapshots(),
         emits(DocumentSnapshotMatcher('abc', {
           'name': 'Bob',
         })));
   });
   test('Snapshots returns a Stream of Snapshot changes', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
     instance.collection('users').snapshots().listen(expectAsync1((snap) {
-      expect(snap.documentChanges.length, 1);
-      expect(snap.documentChanges[0].type, DocumentChangeType.added);
-      expect(snap.documentChanges[0].oldIndex, -1);
-      expect(snap.documentChanges[0].newIndex, 0);
+      expect(snap.docChanges.length, 1);
+      expect(snap.docChanges[0].type, DocumentChangeType.added);
+      expect(snap.docChanges[0].oldIndex, -1);
+      expect(snap.docChanges[0].newIndex, 0);
     }));
   });
   test('Snapshots sets exists property to false if the document does not exist',
       () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
     instance
         .collection('users')
-        .document('doesnotexist')
+        .doc('doesnotexist')
         .snapshots()
         .listen(expectAsync1((document) {
       expect(document.exists, equals(false));
@@ -164,12 +163,12 @@ void main() {
   test('Snapshots sets exists property to true if the document does  exist',
       () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
     instance
         .collection('users')
-        .document(uid)
+        .doc(uid)
         .snapshots()
         .listen(expectAsync1((document) {
       expect(document.exists, equals(true));
@@ -180,51 +179,51 @@ void main() {
     final instance = MockFirestoreInstance();
     final documentReference = instance
         .collection('users')
-        .document('aaa')
+        .doc('aaa')
         .collection('friends')
-        .document('bbb')
+        .doc('bbb')
         .collection('friends-friends')
-        .document('ccc');
+        .doc('ccc');
 
     expect(documentReference.path, 'users/aaa/friends/bbb/friends-friends/ccc');
-    expect(documentReference.parent().path,
-        'users/aaa/friends/bbb/friends-friends');
+    expect(
+        documentReference.parent.path, 'users/aaa/friends/bbb/friends-friends');
   });
 
-  test('Document and collection parent()', () async {
+  test('Document and collection parent', () async {
     final instance = MockFirestoreInstance();
     final documentReference = instance
         .collection('users')
-        .document('aaa')
+        .doc('aaa')
         .collection('friends')
-        .document('bbb')
+        .doc('bbb')
         .collection('friends-friends')
-        .document('ccc');
+        .doc('ccc');
 
-    final friendsFriends = documentReference.parent();
-    final bbb = friendsFriends.parent();
-    final friends = bbb.parent();
-    final bbbSibling = friends.document('bbb-sibling');
+    final friendsFriends = documentReference.parent;
+    final bbb = friendsFriends.parent;
+    final friends = bbb.parent;
+    final bbbSibling = friends.doc('bbb-sibling');
     expect(bbbSibling.path, 'users/aaa/friends/bbb-sibling');
   });
 
   test('firestore field', () async {
     final instance = MockFirestoreInstance();
     final documentReference =
-        instance.collection('users').document('aaa').collection('friends');
+        instance.collection('users').doc('aaa').collection('friends');
 
     expect(documentReference.firestore, instance);
-    expect(documentReference.parent().firestore, instance);
+    expect(documentReference.parent.firestore, instance);
   });
 
   test('Document reference equality', () async {
     final instance = MockFirestoreInstance();
     final documentReference1 = instance
         .collection('users')
-        .document('aaa')
+        .doc('aaa')
         .collection('friends')
-        .document('xyz');
-    final documentReference2 = instance.document('users/aaa/friends/xyz');
+        .doc('xyz');
+    final documentReference2 = instance.doc('users/aaa/friends/xyz');
 
     expect(documentReference1, equals(documentReference2));
   });
@@ -232,75 +231,68 @@ void main() {
   test('Creating document reference should not save the document', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').add(<String, dynamic>{'name': 'Foo'});
-    final documentReference = instance.collection('users').document(uid);
+    final documentReference = instance.collection('users').doc(uid);
 
-    var querySnapshot = await instance.collection('users').getDocuments();
-    expect(querySnapshot.documents, hasLength(1));
+    var querySnapshot = await instance.collection('users').get();
+    expect(querySnapshot.docs, hasLength(1));
 
-    // Only after setData, the document is available for getDocuments
-    await documentReference.setData({'name': 'Bar'});
-    querySnapshot = await instance.collection('users').getDocuments();
-    expect(querySnapshot.documents, hasLength(2));
+    // Only after set, the document is available for get
+    await documentReference.set({'name': 'Bar'});
+    querySnapshot = await instance.collection('users').get();
+    expect(querySnapshot.docs, hasLength(2));
   });
 
-  test('Saving documents in subcollection', () async {
+  test('Saving docs in subcollection', () async {
     final instance = MockFirestoreInstance();
-    // Creates 1st document in "users/abc/friends/<documentId>"
+    // Creates 1st document in "users/abc/friends/<id>"
     await instance
         .collection('users')
-        .document(uid)
+        .doc(uid)
         .collection('friends')
         .add(<String, dynamic>{'name': 'Foo'});
 
     // The command above does not create a document at "users/abc"
     final intermediateDocument =
-        await instance.collection('users').document(uid).get();
+        await instance.collection('users').doc(uid).get();
     expect(intermediateDocument.exists, false);
 
     // Gets a reference to an unsaved document.
-    // This shouldn't appear in getDocuments
-    final documentReference = instance
-        .collection('users')
-        .document(uid)
-        .collection('friends')
-        .document('xyz');
+    // This shouldn't appear in get
+    final documentReference =
+        instance.collection('users').doc(uid).collection('friends').doc('xyz');
     expect(documentReference.path, 'users/$uid/friends/xyz');
 
     var subcollection =
-        instance.collection('users').document(uid).collection('friends');
-    var querySnapshot = await subcollection.getDocuments();
-    expect(querySnapshot.documents, hasLength(1));
+        instance.collection('users').doc(uid).collection('friends');
+    var querySnapshot = await subcollection.get();
+    expect(querySnapshot.docs, hasLength(1));
 
-    // Only after setData, the document is available for getDocuments
-    await documentReference.setData({'name': 'Bar'});
+    // Only after set, the document is available for get
+    await documentReference.set({'name': 'Bar'});
 
     // TODO: Remove the line below once MockQuery defers query execution.
     // https://github.com/atn832/cloud_firestore_mocks/issues/31
-    subcollection =
-        instance.collection('users').document(uid).collection('friends');
-    querySnapshot = await subcollection.getDocuments();
-    expect(querySnapshot.documents, hasLength(2));
+    subcollection = instance.collection('users').doc(uid).collection('friends');
+    querySnapshot = await subcollection.get();
+    expect(querySnapshot.docs, hasLength(2));
   });
 
-  test('Saving documents through FirestoreInstance.document()', () async {
+  test('Saving docs through FirestoreInstance.doc()', () async {
     final instance = MockFirestoreInstance();
 
-    await instance.document('users/$uid/friends/xyz').setData({
+    await instance.doc('users/$uid/friends/xyz').set({
       'name': 'Foo',
       'nested': {
         'k1': 'v1',
       }
     });
 
-    final documentReference = instance
-        .collection('users')
-        .document(uid)
-        .collection('friends')
-        .document('xyz');
+    final documentReference =
+        instance.collection('users').doc(uid).collection('friends').doc('xyz');
 
     final snapshot = await documentReference.get();
-    expect(snapshot.data['name'], 'Foo');
-    final nested = snapshot.data['nested'] as Map<String, dynamic>;
+    expect(snapshot.get('name'), 'Foo');
+    final nested = snapshot.get('nested') as Map<String, dynamic>;
     expect(nested['k1'], 'v1');
   });
 
@@ -309,11 +301,11 @@ void main() {
     final instance = MockFirestoreInstance();
 
     final snapshot1 =
-        await instance.collection('users').document(nonExistentId).get();
+        await instance.collection('users').doc(nonExistentId).get();
     expect(snapshot1, isNotNull);
-    expect(snapshot1.documentID, nonExistentId);
+    expect(snapshot1.id, nonExistentId);
     // data field should be null before the document is saved
-    expect(snapshot1.data, isNull);
+    expect(snapshot1.data(), isNull);
   });
 
   test('Snapshots returns a Stream of Snapshots upon each change', () async {
@@ -353,35 +345,33 @@ void main() {
 
   test('delete', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'username': 'Bob',
     });
-    await instance.collection('users').document(uid).delete();
-    final users = await instance.collection('users').getDocuments();
-    expect(users.documents.isEmpty, equals(true));
+    await instance.collection('users').doc(uid).delete();
+    final users = await instance.collection('users').get();
+    expect(users.docs.isEmpty, equals(true));
     expect(instance.hasSavedDocument('users/abc'), false);
   });
 
   group('FieldValue', () {
     test('FieldValue.delete() deletes key values', () async {
       final firestore = MockFirestoreInstance();
-      await firestore.document('root/foo').setData({'flower': 'rose'});
-      await firestore
-          .document('root/foo')
-          .setData({'flower': FieldValue.delete()});
-      final document = await firestore.document('root/foo').get();
-      expect(document.data.isEmpty, equals(true));
+      await firestore.doc('root/foo').set({'flower': 'rose'});
+      await firestore.doc('root/foo').set({'flower': FieldValue.delete()});
+      final document = await firestore.doc('root/foo').get();
+      expect(document.data().isEmpty, equals(true));
     });
 
     test('FieldValue.serverTimestamp() sets the time', () async {
       final firestore = MockFirestoreInstance();
-      await firestore.collection('users').document(uid).setData({
+      await firestore.collection('users').doc(uid).set({
         'created': FieldValue.serverTimestamp(),
       });
-      final users = await firestore.collection('users').getDocuments();
-      final bob = users.documents.first;
-      expect(bob['created'], isNotNull);
-      final bobCreated = bob['created'] as Timestamp; // Not DateTime
+      final users = await firestore.collection('users').get();
+      final bob = users.docs.first;
+      expect(bob.get('created'), isNotNull);
+      final bobCreated = bob.get('created') as Timestamp; // Not DateTime
       final timeDiff = Timestamp.now().millisecondsSinceEpoch -
           bobCreated.millisecondsSinceEpoch;
       // Mock is fast it shouldn't take more than 1000 milliseconds to execute the code above
@@ -390,135 +380,134 @@ void main() {
 
     test('FieldValue.increment() increments number', () async {
       final firestore = MockFirestoreInstance();
-      // Empty document before updateData
-      await firestore.collection('messages').document(uid).setData({
+      // Empty document before update
+      await firestore.collection('messages').doc(uid).set({
         'int': 0,
         'double': 1.3,
         'previously String': 'foo',
       });
-      await firestore.collection('messages').document(uid).updateData({
+      await firestore.collection('messages').doc(uid).update({
         'user.counter': 5,
       });
 
-      await firestore.collection('messages').document(uid).updateData({
+      await firestore.collection('messages').doc(uid).update({
         'user.counter': FieldValue.increment(2),
         'double': FieldValue.increment(3.3),
         'int': FieldValue.increment(7),
         'previously String': FieldValue.increment(1),
         'previously absent': FieldValue.increment(8),
       });
-      final messages = await firestore.collection('messages').getDocuments();
-      final message = messages.documents.first;
-      expect(message['double'], 1.3 + 3.3);
-      expect(message['int'], 7);
-      final map = message['user'] as Map<String, dynamic>;
+      final messages = await firestore.collection('messages').get();
+      final message = messages.docs.first;
+      expect(message.get('double'), 1.3 + 3.3);
+      expect(message.get('int'), 7);
+      final map = message.get('user') as Map<String, dynamic>;
       expect(map['counter'], 5 + 2);
-      expect(message['previously String'], 1);
-      expect(message['previously absent'], 8);
+      expect(message.get('previously String'), 1);
+      expect(message.get('previously absent'), 8);
     });
 
     test('FieldValue.arrayUnion() adds unique items', () async {
       final firestore = MockFirestoreInstance();
-      // Empty document before updateData
-      await firestore.collection('messages').document(uid).setData({
+      // Empty document before update
+      await firestore.collection('messages').doc(uid).set({
         'array': [1, 2, 3],
         'previously String': 'foo',
       });
-      await firestore.collection('messages').document(uid).updateData({
+      await firestore.collection('messages').doc(uid).update({
         'nested.array': ['a', 'b']
       });
 
-      await firestore.collection('messages').document(uid).updateData({
+      await firestore.collection('messages').doc(uid).update({
         'array': FieldValue.arrayUnion([3, 4, 5]),
         'nested.array': FieldValue.arrayUnion(['b', 'c']),
         'previously String': FieldValue.arrayUnion([6, 7]),
         'previously absent': FieldValue.arrayUnion([8, 9]),
       });
 
-      final messages = await firestore.collection('messages').getDocuments();
-      final snapshot = messages.documents.first;
-      expect(snapshot['array'], [1, 2, 3, 4, 5]);
-      final map = snapshot['nested'] as Map<String, dynamic>;
+      final messages = await firestore.collection('messages').get();
+      final snapshot = messages.docs.first;
+      expect(snapshot.get('array'), [1, 2, 3, 4, 5]);
+      final map = snapshot.get('nested') as Map<String, dynamic>;
       expect(map['array'], ['a', 'b', 'c']);
-      expect(snapshot['previously String'], [6, 7]);
-      expect(snapshot['previously absent'], [8, 9]);
+      expect(snapshot.get('previously String'), [6, 7]);
+      expect(snapshot.get('previously absent'), [8, 9]);
     });
 
     test('FieldValue.arrayRemove() removes items', () async {
       final firestore = MockFirestoreInstance();
-      // Empty document before updateData
-      await firestore.collection('messages').document(uid).setData({
+      // Empty document before update
+      await firestore.collection('messages').doc(uid).set({
         'array': [1, 2, 3],
         'previously String': 'foo',
         'untouched': [3],
       });
-      await firestore.collection('messages').document(uid).updateData({
+      await firestore.collection('messages').doc(uid).update({
         'nested.array': ['a', 'b', 'c']
       });
 
-      await firestore.collection('messages').document(uid).updateData({
+      await firestore.collection('messages').doc(uid).update({
         'array': FieldValue.arrayRemove([3, 4]),
         'nested.array': FieldValue.arrayRemove(['b', 'd']),
         'previously String': FieldValue.arrayRemove([8, 9]),
         'previously absent': FieldValue.arrayRemove([8, 9]),
       });
 
-      final messages = await firestore.collection('messages').getDocuments();
-      final snapshot = messages.documents.first;
-      expect(snapshot['array'], [1, 2]);
-      final map = snapshot['nested'] as Map<String, dynamic>;
+      final messages = await firestore.collection('messages').get();
+      final snapshot = messages.docs.first;
+      expect(snapshot.get('array'), [1, 2]);
+      final map = snapshot.get('nested') as Map<String, dynamic>;
       expect(map['array'], ['a', 'c']);
-      expect(snapshot['untouched'], [3]);
-      expect(snapshot['previously String'], []);
-      expect(snapshot['previously absent'], []);
+      expect(snapshot.get('untouched'), [3]);
+      expect(snapshot.get('previously String'), []);
+      expect(snapshot.get('previously absent'), []);
     });
 
     test('FieldValue in nested objects', () async {
       final firestore = MockFirestoreInstance();
-      final docRef =
-          firestore.collection('MyCollection').document('MyDocument');
+      final docRef = firestore.collection('MyCollection').doc('MyDocument');
       final batch = firestore.batch();
 
-      batch.setData(
+      batch.set(
           docRef,
           {
             'testme': FieldValue.increment(1),
             'updated': FieldValue.serverTimestamp(),
             'Nested': {'testnestedfield': FieldValue.increment(1)}
           },
-          merge: true);
+          SetOptions(merge: true));
       await batch.commit();
 
-      final myDocs = await firestore.collection('MyCollection').getDocuments();
-      expect(myDocs.documents.length, 1);
+      final myDocs = await firestore.collection('MyCollection').get();
+      expect(myDocs.docs.length, 1);
 
       final today = DateTime.now();
-      final myDoc = myDocs.documents.first;
-      final Timestamp updatedTimestamp = myDoc['updated'];
+      final myDoc = myDocs.docs.first;
+      final Timestamp updatedTimestamp = myDoc.get('updated');
       final updated = updatedTimestamp.toDate();
       expect(updated.month, today.month);
       expect(updated.day, today.day);
       expect(updated.year, today.year);
       expect(updated.hour, today.hour);
-      expect(myDoc['testme'], 1);
-      final count = myDoc['Nested']['testnestedfield'];
+      expect(myDoc.get('testme'), 1);
+      final count = myDoc.get('Nested')['testnestedfield'];
       expect(count, 1);
     });
   });
 
-  test('setData to nested documents', () async {
+  test('set to nested docs', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'foo.bar.baz.username': 'SomeName',
       'foo.bar.created': FieldValue.serverTimestamp()
     });
 
-    final snapshot = await instance.collection('users').getDocuments();
-    expect(snapshot.documents.length, equals(1));
-    final topLevelDocument = snapshot.documents.first;
-    expect(topLevelDocument['foo'], isNotNull);
+    final snapshot = await instance.collection('users').get();
+    expect(snapshot.docs.length, equals(1));
+    final topLevelDocument = snapshot.docs.first;
+    expect(topLevelDocument.get('foo'), isNotNull);
     final secondLevelDocument =
-        topLevelDocument['foo'] as Map<dynamic, dynamic>;
+        topLevelDocument.get('foo') as Map<dynamic, dynamic>;
     expect(secondLevelDocument['bar'], isNotNull);
     final thirdLevelDocument =
         secondLevelDocument['bar'] as Map<dynamic, dynamic>;
@@ -534,24 +523,24 @@ void main() {
     expect(timeDiff, lessThan(1000));
   });
 
-  test('updateData to nested documents', () async {
+  test('update to nested docs', () async {
     final instance = MockFirestoreInstance();
 
-    // This field should not be affected by updateData
-    await instance.collection('users').document(uid).setData({
+    // This field should not be affected by update
+    await instance.collection('users').doc(uid).set({
       'foo.bar.baz.username': 'SomeName',
     });
-    await instance.collection('users').document(uid).updateData({
+    await instance.collection('users').doc(uid).update({
       'foo.bar.BAZ.username': 'AnotherName',
     });
 
-    // The updateData should not affect the existing key
-    final snapshot = await instance.collection('users').getDocuments();
-    expect(snapshot.documents.length, equals(1));
-    final topLevelDocument = snapshot.documents.first;
-    expect(topLevelDocument['foo'], isNotNull);
+    // The update should not affect the existing key
+    final snapshot = await instance.collection('users').get();
+    expect(snapshot.docs.length, equals(1));
+    final topLevelDocument = snapshot.docs.first;
+    expect(topLevelDocument.get('foo'), isNotNull);
     final secondLevelDocument =
-        topLevelDocument['foo'] as Map<dynamic, dynamic>;
+        topLevelDocument.get('foo') as Map<dynamic, dynamic>;
     expect(secondLevelDocument['bar'], isNotNull);
     final thirdLevelDocument =
         secondLevelDocument['bar'] as Map<dynamic, dynamic>;
@@ -560,13 +549,13 @@ void main() {
         thirdLevelDocument['baz'] as Map<dynamic, dynamic>;
     expect(fourthLevelDocument['username'], 'SomeName');
 
-    // UpdateData should create the expected object
-    final snapshot2 = await instance.collection('users').getDocuments();
-    expect(snapshot2.documents.length, equals(1));
-    final topLevelDocument2 = snapshot2.documents.first;
-    expect(topLevelDocument2['foo'], isNotNull);
+    // update should create the expected object
+    final snapshot2 = await instance.collection('users').get();
+    expect(snapshot2.docs.length, equals(1));
+    final topLevelDocument2 = snapshot2.docs.first;
+    expect(topLevelDocument2.get('foo'), isNotNull);
     final secondLevelDocument2 =
-        topLevelDocument2['foo'] as Map<dynamic, dynamic>;
+        topLevelDocument2.get('foo') as Map<dynamic, dynamic>;
     expect(secondLevelDocument2['bar'], isNotNull);
     final thirdLevelDocument2 =
         secondLevelDocument2['bar'] as Map<dynamic, dynamic>;
@@ -576,22 +565,22 @@ void main() {
     expect(fourthLevelDocument2['username'], 'AnotherName');
   });
 
-  test('updateData to non-object field', () async {
+  test('update to non-object field', () async {
     final instance = MockFirestoreInstance();
 
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'foo.name': 'String value to be overwritten',
     });
-    // foo.name is a String, but updateData should overwrite it as a Map
-    await instance.collection('users').document(uid).updateData({
+    // foo.name is a String, but update should overwrite it as a Map
+    await instance.collection('users').doc(uid).update({
       'foo.name.firstName': 'Tomo',
     });
 
-    final snapshot = await instance.collection('users').getDocuments();
-    expect(snapshot.documents.length, equals(1));
-    final topLevelDocument = snapshot.documents.first;
-    expect(topLevelDocument['foo'], isNotNull);
-    final foo = topLevelDocument['foo'] as Map<dynamic, dynamic>;
+    final snapshot = await instance.collection('users').get();
+    expect(snapshot.docs.length, equals(1));
+    final topLevelDocument = snapshot.docs.first;
+    expect(topLevelDocument.get('foo'), isNotNull);
+    final foo = topLevelDocument.get('foo') as Map<dynamic, dynamic>;
     expect(foo['name'], isNotNull);
     // name is not a String
     final fooName = foo['name'] as Map<dynamic, dynamic>;
@@ -622,9 +611,9 @@ void main() {
       }
     };
 
-    // 1: setData
-    final document1 = messages.document();
-    await document1.setData(<String, dynamic>{
+    // 1: set
+    final document1 = messages.doc();
+    await document1.set(<String, dynamic>{
       'array': array,
       'map': map,
     });
@@ -635,10 +624,10 @@ void main() {
       'map': map,
     });
 
-    // 3: updateData
-    final document3 = messages.document();
-    await document3.setData({});
-    await document3.updateData({
+    // 3: update
+    final document3 = messages.doc();
+    await document3.set({});
+    await document3.update({
       'array': array,
       'map': map,
     });
@@ -657,7 +646,7 @@ void main() {
     await document2.delete();
     await document3.delete();
 
-    final reasons = ['setData', 'add', 'updateData'];
+    final reasons = ['set', 'add', 'update'];
     final results = [result1, result2, result3];
     for (var i = 0; i < results.length; ++i) {
       final result = results[i];
@@ -673,10 +662,10 @@ void main() {
           }
         }
       ];
-      expect(result.data['array'], expected,
+      expect(result.get('array'), expected,
           reason: 'Array modification should not affect ${reasons[i]}');
 
-      final map1 = result.data['map'] as Map<String, dynamic>;
+      final map1 = result.get('map') as Map<String, dynamic>;
       expect(map1['k1'], 'old value 1',
           reason: 'Map modification should not affect ${reasons[i]}');
       final map2 = map1['nested1'] as Map<String, dynamic>;
@@ -688,12 +677,12 @@ void main() {
 
   test('auto generate ID', () async {
     final firestore = MockFirestoreInstance();
-    final reference1 = firestore.collection('users').document();
-    final document1Id = reference1.documentID;
-    final reference2 = firestore.collection('users').document();
-    expect(document1Id, isNot(reference2.documentID));
+    final reference1 = firestore.collection('users').doc();
+    final document1Id = reference1.id;
+    final reference2 = firestore.collection('users').doc();
+    expect(document1Id, isNot(reference2.id));
 
-    await reference1.setData({
+    await reference1.set({
       'someField': 'someValue',
     });
     final snapshot1 = await reference1.get();
@@ -702,92 +691,91 @@ void main() {
     final snapshot2 = await reference2.get();
     expect(snapshot2.exists, false);
 
-    final snapshot =
-        await firestore.collection('users').document(document1Id).get();
-    expect(snapshot['someField'], 'someValue');
+    final snapshot = await firestore.collection('users').doc(document1Id).get();
+    expect(snapshot.get('someField'), 'someValue');
 
-    final querySnapshot = await firestore.collection('users').getDocuments();
-    expect(querySnapshot.documents, hasLength(1));
-    expect(querySnapshot.documents.first['someField'], 'someValue');
+    final querySnapshot = await firestore.collection('users').get();
+    expect(querySnapshot.docs, hasLength(1));
+    expect(querySnapshot.docs.first.get('someField'), 'someValue');
   });
 
   test('Snapshot before saving data', () async {
     final firestore = MockFirestoreInstance();
-    // These documents are not saved
+    // These docs are not saved
     final nonExistentId = 'salkdjfaarecikvdiko0';
     final snapshot1 =
-        await firestore.collection('users').document(nonExistentId).get();
+        await firestore.collection('users').doc(nonExistentId).get();
     expect(snapshot1, isNotNull);
-    expect(snapshot1.documentID, nonExistentId);
-    expect(snapshot1.data, isNull);
+    expect(snapshot1.id, nonExistentId);
+    expect(snapshot1.data(), isNull);
     expect(snapshot1.exists, false);
 
-    final snapshot2 = await firestore.collection('users').document().get();
+    final snapshot2 = await firestore.collection('users').doc().get();
     expect(snapshot2, isNotNull);
-    expect(snapshot2.documentID.length, greaterThanOrEqualTo(20));
+    expect(snapshot2.id.length, greaterThanOrEqualTo(20));
     expect(snapshot2.exists, false);
   });
 
   test('Snapshot should remain after updating data', () async {
     final firestore = MockFirestoreInstance();
-    // These documents are not saved
-    final reference = firestore.collection('users').document('foo');
-    await reference.setData(<String, dynamic>{'name': 'old'});
-    await reference.updateData(<String, dynamic>{
+    // These docs are not saved
+    final reference = firestore.collection('users').doc('foo');
+    await reference.set(<String, dynamic>{'name': 'old'});
+    await reference.update(<String, dynamic>{
       'nested.data.message': 'old nested data',
     });
 
     final snapshot = await reference.get();
 
-    await reference.setData(<String, dynamic>{'name': 'new'});
-    await reference.updateData(<String, dynamic>{
+    await reference.set(<String, dynamic>{'name': 'new'});
+    await reference.update(<String, dynamic>{
       'nested.data.message': 'new nested data',
     });
 
     // At the time the snapshot was created, the value was 'old'
-    expect(snapshot.data['name'], 'old');
-    final nested = snapshot.data['nested'] as Map<String, dynamic>;
+    expect(snapshot.get('name'), 'old');
+    final nested = snapshot.get('nested') as Map<String, dynamic>;
     final nestedData = nested['data'] as Map<String, dynamic>;
     expect(nestedData['message'], 'old nested data');
   });
 
-  test('Batch setData', () async {
+  test('Batch set', () async {
     final firestore = MockFirestoreInstance();
-    final foo = firestore.collection('users').document('foo');
-    final bar = firestore.collection('users').document('bar');
+    final foo = firestore.collection('users').doc('foo');
+    final bar = firestore.collection('users').doc('bar');
 
     final batch = firestore.batch();
-    batch.setData(foo, <String, dynamic>{'name.firstName': 'Foo'});
-    batch.setData(bar, <String, dynamic>{'name.firstName': 'Bar'});
+    batch.set(foo, <String, dynamic>{'name.firstName': 'Foo'});
+    batch.set(bar, <String, dynamic>{'name.firstName': 'Bar'});
     await batch.commit();
 
-    final docs = await firestore.collection('users').getDocuments();
-    expect(docs.documents, hasLength(2));
+    final docs = await firestore.collection('users').get();
+    expect(docs.docs, hasLength(2));
 
-    final firstNames = docs.documents.map((user) {
-      final nameMap = user['name'] as Map<String, dynamic>;
+    final firstNames = docs.docs.map((user) {
+      final nameMap = user.get('name') as Map<String, dynamic>;
       return nameMap['firstName'];
     });
     expect(firstNames, containsAll(['Foo', 'Bar']));
   });
 
-  test('Batch updateData', () async {
+  test('Batch update', () async {
     final firestore = MockFirestoreInstance();
-    final foo = firestore.collection('users').document('foo');
-    await foo.setData(<String, dynamic>{'name.firstName': 'OldValue Foo'});
-    final bar = firestore.collection('users').document('bar');
-    await foo.setData(<String, dynamic>{'name.firstName': 'OldValue Bar'});
+    final foo = firestore.collection('users').doc('foo');
+    await foo.set(<String, dynamic>{'name.firstName': 'OldValue Foo'});
+    final bar = firestore.collection('users').doc('bar');
+    await foo.set(<String, dynamic>{'name.firstName': 'OldValue Bar'});
 
     final batch = firestore.batch();
-    batch.updateData(foo, <String, dynamic>{'name.firstName': 'Foo'});
-    batch.updateData(bar, <String, dynamic>{'name.firstName': 'Bar'});
+    batch.update(foo, <String, dynamic>{'name.firstName': 'Foo'});
+    batch.update(bar, <String, dynamic>{'name.firstName': 'Bar'});
     await batch.commit();
 
-    final docs = await firestore.collection('users').getDocuments();
-    expect(docs.documents, hasLength(2));
+    final docs = await firestore.collection('users').get();
+    expect(docs.docs, hasLength(2));
 
-    final firstNames = docs.documents.map((user) {
-      final nameMap = user['name'] as Map<String, dynamic>;
+    final firstNames = docs.docs.map((user) {
+      final nameMap = user.get('name') as Map<String, dynamic>;
       return nameMap['firstName'];
     });
     expect(firstNames, containsAll(['Foo', 'Bar']));
@@ -795,31 +783,31 @@ void main() {
 
   test('Batch delete', () async {
     final firestore = MockFirestoreInstance();
-    final foo = firestore.collection('users').document('foo');
-    await foo.setData(<String, dynamic>{'name.firstName': 'Foo'});
-    final bar = firestore.collection('users').document('bar');
-    await foo.setData(<String, dynamic>{'name.firstName': 'Bar'});
+    final foo = firestore.collection('users').doc('foo');
+    await foo.set(<String, dynamic>{'name.firstName': 'Foo'});
+    final bar = firestore.collection('users').doc('bar');
+    await foo.set(<String, dynamic>{'name.firstName': 'Bar'});
 
     await firestore
         .collection('users')
-        .document()
-        .setData(<String, dynamic>{'name.firstName': 'Survivor'});
+        .doc()
+        .set(<String, dynamic>{'name.firstName': 'Survivor'});
 
     final batch = firestore.batch();
     batch.delete(foo);
     batch.delete(bar);
     await batch.commit();
 
-    final docs = await firestore.collection('users').getDocuments();
-    expect(docs.documents, hasLength(1));
-    final savedFoo = docs.documents.first;
-    final nameMap = savedFoo['name'] as Map<String, dynamic>;
+    final docs = await firestore.collection('users').get();
+    expect(docs.docs, hasLength(1));
+    final savedFoo = docs.docs.first;
+    final nameMap = savedFoo.get('name') as Map<String, dynamic>;
     expect(nameMap['firstName'], 'Survivor');
   });
 
   test('MockFirestoreInstance.document with a valid path', () async {
     final firestore = MockFirestoreInstance();
-    final documentReference = firestore.document('users/1234');
+    final documentReference = firestore.doc('users/1234');
     expect(documentReference, isNotNull);
   });
 
@@ -832,10 +820,10 @@ void main() {
     // in iOS, it's NSInternalInconsistencyException that would terminate
     // the app. This library imitates it with assert().
     // https://github.com/atn832/cloud_firestore_mocks/issues/30
-    expect(() => firestore.document('users'), throwsA(isA<AssertionError>()));
+    expect(() => firestore.doc('users'), throwsA(isA<AssertionError>()));
 
     // subcollection
-    expect(() => firestore.document('users/1234/friends'),
+    expect(() => firestore.doc('users/1234/friends'),
         throwsA(isA<AssertionError>()));
   });
 
@@ -853,18 +841,18 @@ void main() {
 
   test('Transaction set, update, and delete', () async {
     final firestore = MockFirestoreInstance();
-    final foo = firestore.collection('messages').document('foo');
-    final bar = firestore.collection('messages').document('bar');
-    final baz = firestore.collection('messages').document('baz');
-    await foo.setData(<String, dynamic>{'name': 'Foo'});
-    await bar.setData(<String, dynamic>{'name': 'Bar'});
-    await baz.setData(<String, dynamic>{'name': 'Baz'});
+    final foo = firestore.collection('messages').doc('foo');
+    final bar = firestore.collection('messages').doc('bar');
+    final baz = firestore.collection('messages').doc('baz');
+    await foo.set(<String, dynamic>{'name': 'Foo'});
+    await bar.set(<String, dynamic>{'name': 'Bar'});
+    await baz.set(<String, dynamic>{'name': 'Baz'});
 
     final result = await firestore.runTransaction((Transaction tx) async {
       final snapshot = await tx.get(foo);
 
       await tx.set(foo, <String, dynamic>{
-        'name': snapshot.data['name'] + 'o',
+        'name': snapshot.get('name') + 'o',
       });
       await tx.update(bar, <String, dynamic>{
         'nested.field': 123,
@@ -875,11 +863,11 @@ void main() {
     expect(result['k'], 'v');
 
     final updatedSnapshotFoo = await foo.get();
-    expect(updatedSnapshotFoo.data['name'], 'Fooo');
+    expect(updatedSnapshotFoo.get('name'), 'Fooo');
 
     final updatedSnapshotBar = await bar.get();
     final nestedDocument =
-        updatedSnapshotBar.data['nested'] as Map<String, dynamic>;
+        updatedSnapshotBar.get('nested') as Map<String, dynamic>;
     expect(nestedDocument['field'], 123);
 
     final deletedSnapshotBaz = await baz.get();
@@ -888,17 +876,17 @@ void main() {
 
   test('Transaction: read must come before writes', () async {
     final firestore = MockFirestoreInstance();
-    final foo = firestore.collection('messages').document('foo');
-    final bar = firestore.collection('messages').document('bar');
-    await foo.setData(<String, dynamic>{'name': 'Foo'});
-    await bar.setData(<String, dynamic>{'name': 'Bar'});
+    final foo = firestore.collection('messages').doc('foo');
+    final bar = firestore.collection('messages').doc('bar');
+    await foo.set(<String, dynamic>{'name': 'Foo'});
+    await bar.set(<String, dynamic>{'name': 'Bar'});
 
     Future<dynamic> erroneousTransactionUsage() async {
       await firestore.runTransaction((Transaction tx) async {
         final snapshotFoo = await tx.get(foo);
 
         await tx.set(foo, <String, dynamic>{
-          'name': snapshotFoo.data['name'] + 'o',
+          'name': snapshotFoo.get('name') + 'o',
         });
         // get cannot come after set
         await tx.get(bar);
@@ -910,38 +898,38 @@ void main() {
 
   test('Document snapshot data returns a new instance', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').document(uid).setData({
+    await instance.collection('users').doc(uid).set({
       'name': 'Eve',
       'friends': ['Alice', 'Bob'],
     });
 
-    final eve = await instance.collection('users').document(uid).get();
-    eve.data['name'] = 'John';
-    eve.data['friends'][0] = 'Superman';
+    final eve = await instance.collection('users').doc(uid).get();
+    eve.data()['name'] = 'John';
+    eve.data()['friends'][0] = 'Superman';
 
-    expect(eve.data['name'], isNot('John')); // nothing changed
-    expect(eve.data['friends'], equals(['Alice', 'Bob'])); // nothing changed
+    expect(eve.get('name'), isNot('John')); // nothing changed
+    expect(eve.get('friends'), equals(['Alice', 'Bob'])); // nothing changed
   });
 
-  test('CollectionGroup getDocuments', () async {
+  test('CollectionGroup get', () async {
     final firestore = MockFirestoreInstance();
-    await firestore.document('foo/foo_1/bar/bar_1').setData({'value': '1'});
-    await firestore.document('foo/foo_2/bar/bar_2').setData({'value': '2'});
-    await firestore.document('bar/bar_3').setData({'value': '3'});
-    final querySnapshot = await firestore.collectionGroup('bar').getDocuments();
-    expect(querySnapshot.documents, hasLength(3));
-    expect(querySnapshot.documents.first.documentID, 'bar_3');
-    expect(querySnapshot.documents.first.reference.path, 'bar/bar_3');
-    expect(querySnapshot.documents.first.data, {'value': '3'});
-    expect(querySnapshot.documents[1].data, {'value': '1'});
-    expect(querySnapshot.documents[2].data, {'value': '2'});
+    await firestore.doc('foo/foo_1/bar/bar_1').set({'value': '1'});
+    await firestore.doc('foo/foo_2/bar/bar_2').set({'value': '2'});
+    await firestore.doc('bar/bar_3').set({'value': '3'});
+    final querySnapshot = await firestore.collectionGroup('bar').get();
+    expect(querySnapshot.docs, hasLength(3));
+    expect(querySnapshot.docs.first.id, 'bar_3');
+    expect(querySnapshot.docs.first.reference.path, 'bar/bar_3');
+    expect(querySnapshot.docs.first.data(), {'value': '3'});
+    expect(querySnapshot.docs[1].data(), {'value': '1'});
+    expect(querySnapshot.docs[2].data(), {'value': '2'});
   });
 
   test('CollectionGroup snapshots', () async {
     final firestore = MockFirestoreInstance();
-    await firestore.document('foo/foo_1/bar/bar_1').setData({'value': '1'});
-    await firestore.document('foo/foo_2/bar/bar_2').setData({'value': '2'});
-    await firestore.document('bar/bar_3').setData({'value': '3'});
+    await firestore.doc('foo/foo_1/bar/bar_1').set({'value': '1'});
+    await firestore.doc('foo/foo_2/bar/bar_2').set({'value': '2'});
+    await firestore.doc('bar/bar_3').set({'value': '3'});
     expect(
         firestore.collectionGroup('bar').snapshots(),
         emits(QuerySnapshotMatcher([
@@ -956,17 +944,17 @@ void main() {
     final firestore = MockFirestoreInstance();
 
     // We add a document to a sub-collection. We obviously expect that document
-    // to exist, even though intermediate documents/collections don't.
+    // to exist, even though intermediate docs/collections don't.
     await firestore
         .collection('santa-claus-todo')
-        .document('family-1')
+        .doc('family-1')
         .collection('children')
-        .document('child-1')
-        .setData({'gift': 'Princess dress'});
+        .doc('child-1')
+        .set({'gift': 'Princess dress'});
     expect(
         firestore
             .collection('santa-claus-todo')
-            .document('family-1')
+            .doc('family-1')
             .collection('children')
             .snapshots(),
         emits(QuerySnapshotMatcher([
@@ -980,8 +968,8 @@ void main() {
     // sub-collection. They should not conflict and we can query both.
     await firestore
         .collection('santa-claus-todo')
-        .document('family-1')
-        .setData({'children': 3});
+        .doc('family-1')
+        .set({'children': 3});
     expect(
         firestore.collection('santa-claus-todo').snapshots(),
         emits(QuerySnapshotMatcher([
@@ -992,7 +980,7 @@ void main() {
     expect(
         firestore
             .collection('santa-claus-todo')
-            .document('family-1')
+            .doc('family-1')
             .collection('children')
             .snapshots(),
         emits(QuerySnapshotMatcher([

--- a/test/document_snapshot_matcher.dart
+++ b/test/document_snapshot_matcher.dart
@@ -24,12 +24,12 @@ class DocumentSnapshotMatcher implements Matcher {
     final snapshot = item as DocumentSnapshot;
     // TODO: generate more meaningful descriptions.
     if (_documentId != null &&
-        !equals(snapshot.documentID).matches(_documentId, matchState)) {
-      equals(snapshot.documentID).describeMismatch(
+        !equals(snapshot.id).matches(_documentId, matchState)) {
+      equals(snapshot.id).describeMismatch(
           _documentId, mismatchDescription, matchState, verbose);
     }
-    if (!equals(snapshot.data).matches(_data, matchState)) {
-      equals(snapshot.data)
+    if (!equals(snapshot.data()).matches(_data, matchState)) {
+      equals(snapshot.data())
           .describeMismatch(_data, mismatchDescription, matchState, verbose);
     }
     return mismatchDescription;
@@ -39,9 +39,9 @@ class DocumentSnapshotMatcher implements Matcher {
   bool matches(item, Map matchState) {
     final snapshot = item as DocumentSnapshot;
     if (_documentId == null) {
-      return equals(snapshot.data).matches(_data, matchState);
+      return equals(snapshot.data()).matches(_data, matchState);
     }
-    return equals(snapshot.documentID).matches(_documentId, matchState) &&
-        equals(snapshot.data).matches(_data, matchState);
+    return equals(snapshot.id).matches(_documentId, matchState) &&
+        equals(snapshot.data()).matches(_data, matchState);
   }
 }

--- a/test/query_snapshot_matcher.dart
+++ b/test/query_snapshot_matcher.dart
@@ -21,9 +21,9 @@ class QuerySnapshotMatcher implements Matcher {
     // TODO: this will crash if there are fewer matchers than documents.
 
     final snapshot = item as QuerySnapshot;
-    for (var i = 0; i < snapshot.documents.length; i++) {
+    for (var i = 0; i < snapshot.docs.length; i++) {
       final matcher = _documentSnapshotMatchers[i];
-      final item = snapshot.documents[i];
+      final item = snapshot.docs[i];
       if (!matcher.matches(item, matchState)) {
         matcher.describeMismatch(
             item, mismatchDescription, matchState, verbose);
@@ -35,12 +35,12 @@ class QuerySnapshotMatcher implements Matcher {
   @override
   bool matches(item, Map matchState) {
     final snapshot = item as QuerySnapshot;
-    if (snapshot.documents.length != _documentSnapshotMatchers.length) {
+    if (snapshot.docs.length != _documentSnapshotMatchers.length) {
       return false;
     }
-    for (var i = 0; i < snapshot.documents.length; i++) {
+    for (var i = 0; i < snapshot.docs.length; i++) {
       final matcher = _documentSnapshotMatchers[i];
-      if (!matcher.matches(snapshot.documents[i], matchState)) {
+      if (!matcher.matches(snapshot.docs[i], matchState)) {
         return false;
       }
     }

--- a/test_driver/field_value_behaviors.dart
+++ b/test_driver/field_value_behaviors.dart
@@ -58,16 +58,16 @@ void main() async {
     ftest('FieldValue.increment', (firestore) async {
       final messages = firestore.collection('messages');
 
-      final doc = messages.document();
+      final doc = messages.doc();
 
-      await doc.setData(<String, dynamic>{
+      await doc.set(<String, dynamic>{
         'message': 'hello firestore',
         'int': 3,
         'double': 2.2,
         'previously String': 'foo',
       });
 
-      await doc.updateData(<String, dynamic>{
+      await doc.update(<String, dynamic>{
         'int': FieldValue.increment(2),
         'double': FieldValue.increment(1.7),
         'previously absent': FieldValue.increment(4),
@@ -78,23 +78,23 @@ void main() async {
 
       await doc.delete();
 
-      expect(snapshot.data['message'], 'hello firestore');
-      expect(snapshot.data['int'], 5);
-      expect(snapshot.data['double'], 2.2 + 1.7);
-      expect(snapshot.data['previously absent'], 4);
-      expect(snapshot.data['previously String'], 5);
+      expect(snapshot.get('message'), 'hello firestore');
+      expect(snapshot.get('int'), 5);
+      expect(snapshot.get('double'), 2.2 + 1.7);
+      expect(snapshot.get('previously absent'), 4);
+      expect(snapshot.get('previously String'), 5);
     });
 
     ftest('FieldValue.serverTimestamp', (firestore) async {
       final messages = firestore.collection('messages');
 
-      final doc = messages.document();
+      final doc = messages.doc();
 
-      await doc.setData(<String, dynamic>{
+      await doc.set(<String, dynamic>{
         'message': 'hello firestore',
       });
 
-      await doc.updateData(<String, dynamic>{
+      await doc.update(<String, dynamic>{
         'timestamp': FieldValue.serverTimestamp(),
       });
 
@@ -106,7 +106,7 @@ void main() async {
       // Cloud Firestore's server. If this fails, ensure your computer's clock
       // is synchronized automatically.
       expect(
-          snapshot.data['timestamp'],
+          snapshot.get('timestamp'),
           within(
               from: Timestamp.now(),
               distance: 5000, // 5 seconds
@@ -114,18 +114,18 @@ void main() async {
                   (t2.millisecondsSinceEpoch - t1.millisecondsSinceEpoch)
                       .abs()));
       // Update should not affect irrelevant fields
-      expect(snapshot.data['message'], 'hello firestore');
+      expect(snapshot.get('message'), 'hello firestore');
     });
 
     ftest('FieldValue.delete', (firestore) async {
       final messages = firestore.collection('messages');
 
-      final doc = messages.document();
+      final doc = messages.doc();
 
       await doc
-          .setData(<String, dynamic>{'field1': 'hello', 'field2': 'firestore'});
+          .set(<String, dynamic>{'field1': 'hello', 'field2': 'firestore'});
 
-      await doc.updateData(<String, dynamic>{
+      await doc.update(<String, dynamic>{
         'field1': FieldValue.delete(),
       });
 
@@ -133,16 +133,16 @@ void main() async {
 
       await doc.delete();
 
-      expect(snapshot.data['field1'], isNull);
-      expect(snapshot.data['field2'], 'firestore');
+      expect(snapshot.get('field1'), isNull);
+      expect(snapshot.get('field2'), 'firestore');
     });
 
     ftest('FieldValue.arrayUnion', (firestore) async {
       final messages = firestore.collection('messages');
 
-      final doc = messages.document();
+      final doc = messages.doc();
 
-      await doc.setData(<String, dynamic>{
+      await doc.set(<String, dynamic>{
         'array': [1, 2],
         'empty array in document': [],
         'empty array in argument': [4, 5],
@@ -150,13 +150,13 @@ void main() async {
         'duplicate elements in document': [1, 2, 2],
         'duplicate elements in arguments': [1, 2, 3],
         'document reference array': [
-          firestore.document('users/abc/friends/001'),
-          firestore.document('users/abc/friends/002')
+          firestore.doc('users/abc/friends/001'),
+          firestore.doc('users/abc/friends/002')
         ],
         'previously String': 'foo',
       });
 
-      await doc.updateData(<String, dynamic>{
+      await doc.update(<String, dynamic>{
         'array': FieldValue.arrayUnion([1, 3]),
         'empty array in document': FieldValue.arrayUnion([1, 2, 3]),
         'empty array in argument': FieldValue.arrayUnion([]),
@@ -164,8 +164,8 @@ void main() async {
         'duplicate elements in document': FieldValue.arrayUnion([2, 3, 4]),
         'duplicate elements in arguments': FieldValue.arrayUnion([4, 3, 4, 5]),
         'document reference array': FieldValue.arrayUnion([
-          firestore.document('users/abc/friends/003'),
-          firestore.document('users/abc/friends/002') // duplicate
+          firestore.doc('users/abc/friends/003'),
+          firestore.doc('users/abc/friends/002') // duplicate
         ]),
         'previously String': FieldValue.arrayUnion([1, 2, 3]),
         'previously absent': FieldValue.arrayUnion([1, 2, 3]),
@@ -175,29 +175,29 @@ void main() async {
 
       await doc.delete();
 
-      expect(snapshot.data['array'], [1, 2, 3]);
-      expect(snapshot.data['empty array in document'], [1, 2, 3]);
-      expect(snapshot.data['empty array in argument'], [4, 5]);
-      expect(snapshot.data['string and int array'],
+      expect(snapshot.get('array'), [1, 2, 3]);
+      expect(snapshot.get('empty array in document'), [1, 2, 3]);
+      expect(snapshot.get('empty array in argument'), [4, 5]);
+      expect(snapshot.get('string and int array'),
           [1, 2, 'three', 'four', 'five', 6]);
-      expect(snapshot.data['duplicate elements in document'], [1, 2, 2, 3, 4]);
-      expect(snapshot.data['duplicate elements in arguments'], [1, 2, 3, 4, 5]);
-      expect(snapshot.data['document reference array'], [
-        firestore.document('users/abc/friends/001'),
-        firestore.document('users/abc/friends/002'),
-        firestore.document('users/abc/friends/003'),
+      expect(snapshot.get('duplicate elements in document'), [1, 2, 2, 3, 4]);
+      expect(snapshot.get('duplicate elements in arguments'), [1, 2, 3, 4, 5]);
+      expect(snapshot.get('document reference array'), [
+        firestore.doc('users/abc/friends/001'),
+        firestore.doc('users/abc/friends/002'),
+        firestore.doc('users/abc/friends/003'),
       ]);
 
-      expect(snapshot.data['previously String'], [1, 2, 3]);
-      expect(snapshot.data['previously absent'], [1, 2, 3]);
+      expect(snapshot.get('previously String'), [1, 2, 3]);
+      expect(snapshot.get('previously absent'), [1, 2, 3]);
     });
 
     ftest('FieldValue.arrayRemove', (firestore) async {
       final messages = firestore.collection('messages');
 
-      final doc = messages.document();
+      final doc = messages.doc();
 
-      await doc.setData(<String, dynamic>{
+      await doc.set(<String, dynamic>{
         'array': [1, 2],
         'empty array in document': [],
         'empty array in argument': [4, 5],
@@ -207,7 +207,7 @@ void main() async {
         'previously String': 'foo',
       });
 
-      await doc.updateData(<String, dynamic>{
+      await doc.update(<String, dynamic>{
         'array': FieldValue.arrayRemove([1, 3]),
         'empty array in document': FieldValue.arrayRemove([1, 2, 3]),
         'empty array in argument': FieldValue.arrayRemove([]),
@@ -222,14 +222,14 @@ void main() async {
 
       await doc.delete();
 
-      expect(snapshot.data['array'], [2]);
-      expect(snapshot.data['empty array in document'], []);
-      expect(snapshot.data['empty array in argument'], [4, 5]);
-      expect(snapshot.data['string and int array'], [1, 'three']);
-      expect(snapshot.data['duplicate elements in document'], [1]);
-      expect(snapshot.data['duplicate elements in arguments'], [1, 2]);
-      expect(snapshot.data['previously String'], []);
-      expect(snapshot.data['previously absent'], []);
+      expect(snapshot.get('array'), [2]);
+      expect(snapshot.get('empty array in document'), []);
+      expect(snapshot.get('empty array in argument'), [4, 5]);
+      expect(snapshot.get('string and int array'), [1, 'three']);
+      expect(snapshot.get('duplicate elements in document'), [1]);
+      expect(snapshot.get('duplicate elements in arguments'), [1, 2]);
+      expect(snapshot.get('previously String'), []);
+      expect(snapshot.get('previously absent'), []);
     });
   });
 }

--- a/test_driver/firestore_clients.dart
+++ b/test_driver/firestore_clients.dart
@@ -4,21 +4,21 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-Future<Firestore> createFireStoreClient(
+Future<FirebaseFirestore> createFireStoreClient(
     String appName, String host, bool sslEnabled) async {
   // This is from https://github.com/FirebaseExtended/flutterfire/blob/master/packages/cloud_firestore/cloud_firestore/example/test_driver/cloud_firestore.dart
   final firebaseOptions = const FirebaseOptions(
-    googleAppID: '1:79601577497:ios:5f2bcc6ba8cecddd',
-    gcmSenderID: '79601577497',
+    appId: '1:79601577497:ios:5f2bcc6ba8cecddd',
+    messagingSenderId: '79601577497',
     apiKey: 'AIzaSyArgmRGfB5kiQT6CunAOmKRVKEsxKmy6YI-G72PVU',
-    projectID: 'flutter-firestore',
+    projectId: 'flutter-firestore',
   );
-  final app = await FirebaseApp.configure(
+  final app = await Firebase.initializeApp(
     name: appName,
     options: firebaseOptions,
   );
-  final firestore = Firestore(app: app);
-  await firestore.settings(
+  final firestore = FirebaseFirestore.instanceFor(app: app);
+  firestore.settings = Settings(
     persistenceEnabled: true,
     host: host,
     sslEnabled: sslEnabled,
@@ -28,9 +28,9 @@ Future<Firestore> createFireStoreClient(
 }
 
 // Firestore instances to compare their behavior
-Map<String, Future<Firestore>> firestoreFutures = {};
+Map<String, Future<FirebaseFirestore>> firestoreFutures = {};
 
-typedef TestCase = Future<void> Function(Firestore firestore);
+typedef TestCase = Future<void> Function(FirebaseFirestore firestore);
 
 void ftest(String testName, TestCase testCase) {
   if (firestoreFutures.isEmpty) {


### PR DESCRIPTION
## Overview
support cloude_firestore 0.14 version.
From the version, we have to migrate. See: https://firebase.flutter.dev/docs/migration

This PR resolve https://github.com/atn832/cloud_firestore_mocks/issues/125.

Although **I made meaningful commit mesaages and separated commits based on migration step as far as possible**, diff is very big.

### important commits
1. https://github.com/sensuikan1973/cloud_firestore_mocks/pull/4/commits/bbfe14183328d3d08a21ab145981e81abbd8e2a4: update-firebase-plugins
2. https://github.com/sensuikan1973/cloud_firestore_mocks/pull/4/commits/510bf084c9efc6018ba66d38e26be522b8a3ae92: platform-setup
3. https://github.com/sensuikan1973/cloud_firestore_mocks/pull/4/commits/3957cdb658239447c807e79e776f2484324712d6: follow breaking/new changes
4. https://github.com/sensuikan1973/cloud_firestore_mocks/pull/4/commits/83fdb9c4d4f1aa788174be27bf2285661dc8f30e: fix ios gitignore
5. https://github.com/sensuikan1973/cloud_firestore_mocks/pull/4/commits/6c0d4978aea315a48a5f6ab6a7a462afc4a5537e: also example

### driver_test
I also ensured that driver_test and example runs.

<img src="https://user-images.githubusercontent.com/23427957/91582855-6015f880-e98b-11ea-83e8-fb9858f3e311.png" width="200">

When you run driver_test, some warning messages will appear. But, I don't follow that on this PR. Those warning have nothing to do with this migration task.
```sh
# driver_test. iOS log.
$ flutter driver -d XXX --driver=test_driver/cloud_firestore_test.dart
Your Flutter application is created using an older version of the Android embedding. It's being deprecated in favor of Android embedding v2. Follow the steps on https://flutter.dev/go/android-project-migration to migrate your project.
Starting application: lib/main.dart
Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Warning: Podfile is out of date
  This can cause issues if your application depends on plugins that do not support iOS.
  See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms for details.
  If you have local Podfile edits you would like to keep, see https://github.com/flutter/flutter/issues/45197 for instructions.
To regenerate the Podfile, run:
  rm ios/Podfile

Running Xcode build...                                                  
 └─Compiling, linking and signing...                         4.4s
Xcode build done.                                           17.9s
6.26.0 - [Firebase/Core][I-COR000005] No app has been configured yet.
flutter: Observatory listening on http://127.0.0.1:55783/f6cmk1XVQRI=/
VMServiceFlutterDriver: Connecting to Flutter application at http://127.0.0.1:55783/f6cmk1XVQRI=/
VMServiceFlutterDriver: Isolate found with number: 3181536263056123
VMServiceFlutterDriver: Isolate is paused at start.
VMServiceFlutterDriver: Attempting to resume isolate
VMServiceFlutterDriver: Connected to Flutter application.
Stopping application instance.
```