### PR TITLE
fix runTransaction return type bug

### DIFF
--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -85,7 +85,7 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
       handlerResult.values.forEach(_validateTransactionReturnValue);
     }
 
-    return handlerResult ?? {};
+    return handlerResult;
   }
 
   /// Throws PlatformException when the value is not allowed as values of the

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -182,7 +182,7 @@ class _DummyTransaction implements Transaction {
   Transaction delete(DocumentReference documentReference) {
     _foundWrite = true;
     documentReference.delete();
-    return _DummyTransaction();
+    return this;
   }
 
   @override
@@ -190,7 +190,7 @@ class _DummyTransaction implements Transaction {
       DocumentReference documentReference, Map<String, dynamic> data) {
     _foundWrite = true;
     documentReference.update(data);
-    return _DummyTransaction();
+    return this;
   }
 
   @override
@@ -199,6 +199,6 @@ class _DummyTransaction implements Transaction {
       [SetOptions options]) {
     _foundWrite = true;
     documentReference.set(data);
-    return _DummyTransaction();
+    return this;
   }
 }

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -78,38 +78,6 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
     return await transactionHandler(transaction);
   }
 
-  /// Throws PlatformException when the value is not allowed as values of the
-  /// return map of runTransaction. The behavior is not documented in Firestore,
-  /// but our example/test_driver/cloud_firestore_behaviors.dart verifies at
-  /// least the types listed in this function are allowed.
-  /// https://firebase.google.com/docs/reference/android/com/google/firebase/functions/HttpsCallableReference#public-taskhttpscallableresult-call-object-data
-  void _validateTransactionReturnValue(dynamic value) {
-    if (value == null ||
-        value is int ||
-        value is double ||
-        value is bool ||
-        value is String ||
-        value is DateTime ||
-        value is Timestamp ||
-        value is GeoPoint ||
-        value is Blob) {
-      return;
-    } else if (value is List) {
-      for (final element in value) {
-        _validateTransactionReturnValue(element);
-      }
-      return;
-    } else if (value is Map<String, dynamic>) {
-      for (final element in value.values) {
-        _validateTransactionReturnValue(element);
-      }
-      return;
-    }
-    throw PlatformException(
-        code: 'error',
-        message: 'Invalid argument: Instance of ${value.runtimeType}');
-  }
-
   String dump() {
     final copy = deepCopy(_root);
 

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -75,17 +75,7 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
   Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler,
       {Duration timeout = const Duration(seconds: 30)}) async {
     Transaction transaction = _DummyTransaction();
-    final handlerResult = await transactionHandler(transaction);
-
-    // While cloud_firestore's TransactionHandler does not specify the
-    // return value type, runTransaction expects returning a map.
-    // When TransactionHandler returns void, it returns an empty map.
-    // https://github.com/FirebaseExtended/flutterfire/issues/1642
-    if (handlerResult is Map<String, dynamic>) {
-      handlerResult.values.forEach(_validateTransactionReturnValue);
-    }
-
-    return handlerResult;
+    return await transactionHandler(transaction);
   }
 
   /// Throws PlatformException when the value is not allowed as values of the

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -874,11 +874,10 @@ void main() {
     expect(deletedSnapshotBaz.exists, false);
   });
 
-  test('Transaction update. not return value.', () async {
+  test('Transaction update. runTransaction does not return value.', () async {
     final instance = MockFirestoreInstance();
-    const docId = 'foo';
     const user = {'name': 'Bob'};
-    final userDocRef = instance.collection('users').doc(docId);
+    final userDocRef = instance.collection('users').doc();
     await userDocRef.set(user);
 
     await instance.runTransaction((transaction) async {

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -874,6 +874,24 @@ void main() {
     expect(deletedSnapshotBaz.exists, false);
   });
 
+  test('Transaction update. not return value.', () async {
+    final instance = MockFirestoreInstance();
+    const docId = 'foo';
+    const user = {'name': 'Bob'};
+    final userDocRef = instance.collection('users').doc(docId);
+    await userDocRef.set(user);
+
+    await instance.runTransaction((transaction) async {
+      final snapshot = await transaction.get(userDocRef);
+      final data = {'name': 'Mr. ' + snapshot.get('name')};
+      transaction.update(userDocRef, data);
+      // NOTE: not return value
+    });
+
+    final snapshot = await userDocRef.get();
+    expect(snapshot.get('name'), 'Mr. Bob');
+  });
+
   test('Transaction: read must come before writes', () async {
     final firestore = MockFirestoreInstance();
     final foo = firestore.collection('messages').doc('foo');


### PR DESCRIPTION
## Overview
resolve https://github.com/atn832/cloud_firestore_mocks/issues/129

### background
I changed Transaction in https://github.com/atn832/cloud_firestore_mocks/pull/127/files#diff-f88a1580752ecb4e5e77d48fd3ef7cfcL75.
The background is **https://github.com/FirebaseExtended/flutterfire/commit/27d574e620c3a95792682397b12e54e40abe572f#diff-4b03d320cd06661a52dd22772cf78abfL82-R181**

But, I also had to change the return value of runTransaction.