### PR TITLE
fix dump with document reference

### DIFF
--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -92,7 +92,11 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
         // property, the sub-category takes precedence, meaning the returned
         // json will not return that document property.
         if (!docCopy.containsKey(property.key)) {
-          docCopy[property.key] = property.value;
+          final propertyValue = property.value;
+          docCopy[property.key] = propertyValue is MockDocumentReference ? {
+            'type': 'DocumentReference',
+            'path': propertyValue.path,
+          } : propertyValue;
         }
       }
     }

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -20,6 +20,7 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
   /// Saved documents' full paths from root. For example:
   /// 'users/abc/friends/foo'
   final Set<String> _savedDocumentPaths = <String>{};
+
   MockFirestoreInstance() {
     _setupFieldValueFactory();
   }
@@ -78,17 +79,18 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
     return await transactionHandler(transaction);
   }
 
-  dynamic deepFixDocumentReferenceProperty(dynamic propertyValue){
-    if( propertyValue is MockDocumentReference) return propertyValue.toJson();
+  dynamic deepFixDocumentReferenceProperty(dynamic propertyValue) {
+    if (propertyValue is MockDocumentReference) return propertyValue.toJson();
 
-    if(propertyValue is List){
-      for(var i = 0; i<propertyValue.length; i++){
+    if (propertyValue is List) {
+      for (var i = 0; i < propertyValue.length; i++) {
         propertyValue[i] = deepFixDocumentReferenceProperty(propertyValue[i]);
       }
     }
-    if(propertyValue is Map){
-      for(var mapProperty in propertyValue.entries){
-        propertyValue[mapProperty.key] = deepFixDocumentReferenceProperty(mapProperty.value);
+    if (propertyValue is Map) {
+      for (var mapProperty in propertyValue.entries) {
+        propertyValue[mapProperty.key] =
+            deepFixDocumentReferenceProperty(mapProperty.value);
       }
     }
 
@@ -109,7 +111,8 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
         // property, the sub-category takes precedence, meaning the returned
         // json will not return that document property.
         if (!docCopy.containsKey(property.key)) {
-          docCopy[property.key] = deepFixDocumentReferenceProperty(property.value);
+          docCopy[property.key] =
+              deepFixDocumentReferenceProperty(property.value);
         }
       }
     }

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -78,6 +78,23 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
     return await transactionHandler(transaction);
   }
 
+  dynamic deepFixDocumentReferenceProperty(dynamic propertyValue){
+    if( propertyValue is MockDocumentReference) return propertyValue.toJson();
+
+    if(propertyValue is List){
+      for(var i = 0; i<propertyValue.length; i++){
+        propertyValue[i] = deepFixDocumentReferenceProperty(propertyValue[i]);
+      }
+    }
+    if(propertyValue is Map){
+      for(var mapProperty in propertyValue.entries){
+        propertyValue[mapProperty.key] = deepFixDocumentReferenceProperty(mapProperty.value);
+      }
+    }
+
+    return propertyValue;
+  }
+
   String dump() {
     final copy = deepCopy(_root);
 
@@ -92,11 +109,7 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
         // property, the sub-category takes precedence, meaning the returned
         // json will not return that document property.
         if (!docCopy.containsKey(property.key)) {
-          final propertyValue = property.value;
-          docCopy[property.key] = propertyValue is MockDocumentReference ? {
-            'type': 'DocumentReference',
-            'path': propertyValue.path,
-          } : propertyValue;
+          docCopy[property.key] = deepFixDocumentReferenceProperty(property.value);
         }
       }
     }

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -170,4 +170,10 @@ class MockDocumentReference extends Mock implements DocumentReference {
 
   @override
   int get hashCode => _path.hashCode + _firestore.hashCode;
+
+  Map<String, dynamic> toJson() =>
+      {
+        'type': 'DocumentReference',
+        'path': _path,
+      };
 }

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -171,8 +171,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
   @override
   int get hashCode => _path.hashCode + _firestore.hashCode;
 
-  Map<String, dynamic> toJson() =>
-      {
+  Map<String, dynamic> toJson() => {
         'type': 'DocumentReference',
         'path': _path,
       };

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -58,7 +58,7 @@ void main() {
 }'''));
     });
 
-    test('dump with referrence', () async {
+    test('should dump with reference', () async {
       final instance = MockFirestoreInstance();
       final doc1Path = 'messages/test_id1';
       final doc2Path = 'messages/test_id2';
@@ -85,6 +85,140 @@ void main() {
 }'''));
 
     });
+
+    test('should dump with list of references', () async {
+      final instance = MockFirestoreInstance();
+      final doc1Path = 'messages/test_id1';
+      final doc2Path = 'messages/test_id2';
+      final doc3Path = 'messages/test_id3';
+      await instance.doc(doc1Path).set({
+        'content': 'hello!',
+      });
+      await instance.doc(doc2Path).set({
+        'content': 'hello world!',
+      });
+      await instance.doc(doc3Path).set({
+        'ref': [
+          instance.doc(doc1Path),
+          instance.doc(doc2Path),
+        ],
+      });
+      final result = (await instance.doc(doc3Path).get()).data();
+      expect(result['ref'].length, greaterThanOrEqualTo(2));
+      expect(result['ref'][0].path, doc1Path);
+      expect(result['ref'][1].path, doc2Path);
+      expect(instance.dump(), equals('''{
+  "messages": {
+    "test_id1": {
+      "content": "hello!"
+    },
+    "test_id2": {
+      "content": "hello world!"
+    },
+    "test_id3": {
+      "ref": [
+        {
+          "type": "DocumentReference",
+          "path": "${doc1Path}"
+        },
+        {
+          "type": "DocumentReference",
+          "path": "${doc2Path}"
+        }
+      ]
+    }
+  }
+}'''));
+
+    });
+    test('should dump with list of map references', () async {
+      final instance = MockFirestoreInstance();
+      final doc1Path = 'messages/test_id1';
+      final doc2Path = 'messages/test_id2';
+      final doc3Path = 'messages/test_id3';
+      await instance.doc(doc1Path).set({
+        'content': 'hello!',
+      });
+      await instance.doc(doc2Path).set({
+        'content': 'hello world!',
+      });
+      await instance.doc(doc3Path).set({
+        'ref': [
+          {
+            'doc1_ref': instance.doc(doc1Path)
+          },
+          {
+            'doc2_ref': instance.doc(doc2Path)
+          },
+        ],
+      });
+      final result = (await instance.doc(doc3Path).get()).data();
+      expect(result['ref'].length, greaterThanOrEqualTo(2));
+      expect(result['ref'][0]['doc1_ref'].path, doc1Path);
+      expect(result['ref'][1]['doc2_ref'].path, doc2Path);
+      expect(instance.dump(), equals('''{
+  "messages": {
+    "test_id1": {
+      "content": "hello!"
+    },
+    "test_id2": {
+      "content": "hello world!"
+    },
+    "test_id3": {
+      "ref": [
+        {
+          "doc1_ref": {
+            "type": "DocumentReference",
+            "path": "${doc1Path}"
+          }
+        },
+        {
+          "doc2_ref": {
+            "type": "DocumentReference",
+            "path": "${doc2Path}"
+          }
+        }
+      ]
+    }
+  }
+}'''));
+
+    });
+
+    test('should dump with map of map reference', () async {
+      final instance = MockFirestoreInstance();
+      final doc1Path = 'messages/test_id1';
+      final doc2Path = 'messages/test_id2';
+      await instance.doc(doc1Path).set({
+        'content': 'hello!',
+      });
+      await instance.doc(doc2Path).set({
+        'ref': {
+          'doc1_ref': instance.doc(doc1Path)
+        },
+      });
+      final result = (await instance.doc(doc2Path).get()).data();
+      expect(result['ref']['doc1_ref'].path, doc1Path);
+      expect(instance.dump(), equals('''{
+  "messages": {
+    "test_id1": {
+      "content": "hello!"
+    },
+    "test_id2": {
+      "ref": {
+        "doc1_ref": {
+          "type": "DocumentReference",
+          "path": "${doc1Path}"
+        }
+      }
+    }
+  }
+}'''));
+
+    });
+
+
+
 
   });
 

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -57,6 +57,35 @@ void main() {
   }
 }'''));
     });
+
+    test('dump with referrence', () async {
+      final instance = MockFirestoreInstance();
+      final doc1Path = 'messages/test_id1';
+      final doc2Path = 'messages/test_id2';
+      await instance.doc(doc1Path).set({
+        'content': 'hello!',
+      });
+      await instance.doc(doc2Path).set({
+        'ref': instance.doc(doc1Path),
+      });
+      final result = (await instance.doc(doc2Path).get()).data();
+      expect(result['ref'].path, equals(doc1Path));
+      expect(instance.dump(), equals('''{
+  "messages": {
+    "test_id1": {
+      "content": "hello!"
+    },
+    "test_id2": {
+      "ref": {
+        "type": "DocumentReference",
+        "path": "${doc1Path}"
+      }
+    }
+  }
+}'''));
+
+    });
+
   });
 
   group('adding data through collection reference', () {

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -83,7 +83,6 @@ void main() {
     }
   }
 }'''));
-
     });
 
     test('should dump with list of references', () async {
@@ -129,7 +128,6 @@ void main() {
     }
   }
 }'''));
-
     });
     test('should dump with list of map references', () async {
       final instance = MockFirestoreInstance();
@@ -144,12 +142,8 @@ void main() {
       });
       await instance.doc(doc3Path).set({
         'ref': [
-          {
-            'doc1_ref': instance.doc(doc1Path)
-          },
-          {
-            'doc2_ref': instance.doc(doc2Path)
-          },
+          {'doc1_ref': instance.doc(doc1Path)},
+          {'doc2_ref': instance.doc(doc2Path)},
         ],
       });
       final result = (await instance.doc(doc3Path).get()).data();
@@ -182,7 +176,6 @@ void main() {
     }
   }
 }'''));
-
     });
 
     test('should dump with map of map reference', () async {
@@ -193,9 +186,7 @@ void main() {
         'content': 'hello!',
       });
       await instance.doc(doc2Path).set({
-        'ref': {
-          'doc1_ref': instance.doc(doc1Path)
-        },
+        'ref': {'doc1_ref': instance.doc(doc1Path)},
       });
       final result = (await instance.doc(doc2Path).get()).data();
       expect(result['ref']['doc1_ref'].path, doc1Path);
@@ -214,12 +205,7 @@ void main() {
     }
   }
 }'''));
-
     });
-
-
-
-
   });
 
   group('adding data through collection reference', () {


### PR DESCRIPTION
In the previous version. If there contains any DocumentReference fields. call to `instance.dump()` will throw an error `Converting object to an encodable object failed: Instance of 'MockDocumentReference' `

This pull request is fixing it.