### PR TITLE
support null-safety

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: firestore_example
 description: Demonstrates how to use the cloud_firestore_mocks plugin.
 
 environment:
-  sdk: ">=2.9.1 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -11,8 +11,6 @@ dependencies:
   firebase_core: ^1.0.0
 
 dev_dependencies:
-  flutter_driver:
-    sdk: flutter
   test: any
   cloud_firestore_mocks:
     path: ../

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -118,6 +118,10 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
     firestore_interface.FieldValueFactoryPlatform.instance =
         MockFieldValueFactoryPlatform();
   }
+
+  // Required because FirebaseFirestore' == expects dynamic, while Mock's == expects an object.
+  @override
+  bool operator ==(dynamic other) => identical(this, other);
 }
 
 /// Dummy transaction object that sequentially executes the operations without
@@ -154,7 +158,7 @@ class _DummyTransaction implements Transaction {
   @override
   Transaction set(
       DocumentReference documentReference, Map<String, dynamic> data,
-      [SetOptions options]) {
+      [SetOptions? options]) {
     _foundWrite = true;
     documentReference.set(data);
     return this;

--- a/lib/src/mock_collection_reference_platform.dart
+++ b/lib/src/mock_collection_reference_platform.dart
@@ -1,0 +1,5 @@
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:mockito/mockito.dart';
+
+class MockCollectionReferencePlatform extends Mock
+    implements CollectionReferencePlatform {}

--- a/lib/src/mock_document_change.dart
+++ b/lib/src/mock_document_change.dart
@@ -10,9 +10,9 @@ class MockDocumentChange extends Mock implements DocumentChange {
   MockDocumentChange(
     this._document,
     this._type, {
-    int oldIndex,
-    int newIndex,
-  })  : _oldIndex = oldIndex,
+    required int oldIndex,
+    required int newIndex,
+  })   : _oldIndex = oldIndex,
         _newIndex = newIndex;
 
   @override

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:mockito/mockito.dart';
 
+import 'mock_document_reference_platform.dart';
 import 'cloud_firestore_mocks_base.dart';
 import 'mock_collection_reference.dart';
 import 'mock_document_snapshot.dart';
@@ -36,7 +37,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
       this.docsData, this.rootParent, this.snapshotStreamControllerRoot);
 
   // ignore: unused_field
-  final DocumentReferencePlatform _delegate = null;
+  final DocumentReferencePlatform _delegate = MockDocumentReferencePlatform();
 
   @override
   FirebaseFirestore get firestore => _firestore;
@@ -144,7 +145,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
   }
 
   @override
-  Future<void> set(Map<String, dynamic> data, [SetOptions setOptions]) {
+  Future<void> set(Map<String, dynamic> data, [SetOptions? setOptions]) {
     final merge = setOptions?.merge ?? false;
     if (!merge && docsData.containsKey(_path)) {
       docsData[_path].clear();
@@ -153,7 +154,7 @@ class MockDocumentReference extends Mock implements DocumentReference {
   }
 
   @override
-  Future<DocumentSnapshot> get([GetOptions getOptions]) {
+  Future<DocumentSnapshot> get([GetOptions? getOptions]) {
     return Future.value(
         MockDocumentSnapshot(this, _id, docsData[_path], _exists()));
   }

--- a/lib/src/mock_document_reference_platform.dart
+++ b/lib/src/mock_document_reference_platform.dart
@@ -1,0 +1,5 @@
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:mockito/mockito.dart';
+
+class MockDocumentReferencePlatform extends Mock
+    implements DocumentReferencePlatform {}

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -7,22 +7,22 @@ import 'util.dart';
 
 class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
   final String _id;
-  final Map<String, dynamic> _document;
+  final Map<String, dynamic>? _document;
   final bool _exists;
-  final MockDocumentReference _reference;
+  final DocumentReference _reference;
 
   MockDocumentSnapshot(
-      this._reference, this._id, Map<String, dynamic> document, this._exists)
+      this._reference, this._id, Map<String, dynamic>? document, this._exists)
       : _document = deepCopy(document);
 
   @override
   String get id => _id;
 
   @override
-  dynamic get(dynamic key) => _document[key];
+  dynamic get(dynamic key) => _document![key];
 
   @override
-  Map<String, dynamic> data() {
+  Map<String, dynamic>? data() {
     if (_exists) {
       return deepCopy(_document);
     } else {

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -267,9 +267,7 @@ class QuerySnapshotStreamManager {
   String _retrieveParentPath(MockQuery query) {
     // In theory retrieveParentPath should stop at the collection reference.
     // So _parentQuery can never be null.
-    if (query._parentQuery == null) {
-      throw 'Unexpected';
-    }
+    assert(query._parentQuery != null);
     if (query._parentQuery is CollectionReference) {
       return (query._parentQuery as CollectionReference).path;
     } else {
@@ -302,10 +300,8 @@ class QuerySnapshotStreamManager {
     final pathCache = _streamCache[path];
     // Before calling `getStreamController(query)`, one should have called
     // `register(query)` beforehand, so pathCache should never be null.
-    if (pathCache == null) {
-      throw 'Unexpected';
-    }
-    return pathCache[query]!;
+    assert(pathCache != null);
+    return pathCache![query]!;
   }
 
   void fireSnapshotUpdate(String path) {

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -1,11 +1,10 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/src/mock_document_reference.dart';
 
 import 'mock_document_snapshot.dart';
 
 class MockQueryDocumentSnapshot extends MockDocumentSnapshot
     implements QueryDocumentSnapshot {
-  MockQueryDocumentSnapshot(MockDocumentReference reference, String documentId,
-      Map<String, dynamic> document)
+  MockQueryDocumentSnapshot(DocumentReference reference, String documentId,
+      Map<String, dynamic>? document)
       : super(reference, documentId, document, true);
 }

--- a/lib/src/mock_query_platform.dart
+++ b/lib/src/mock_query_platform.dart
@@ -1,0 +1,4 @@
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:mockito/mockito.dart';
+
+class MockQueryPlatform extends Mock implements QueryPlatform {}

--- a/lib/src/mock_write_batch.dart
+++ b/lib/src/mock_write_batch.dart
@@ -8,7 +8,7 @@ class MockWriteBatch extends Mock implements WriteBatch {
 
   @override
   void set(DocumentReference document, Map<String, dynamic> data,
-      [SetOptions setOptions]) {
+      [SetOptions? setOptions]) {
     tasks.add(WriteTask()
       ..command = WriteCommand.setData
       ..document = document
@@ -34,19 +34,19 @@ class MockWriteBatch extends Mock implements WriteBatch {
   @override
   Future<void> commit() {
     for (final task in tasks) {
-      switch (task.command) {
+      switch (task.command!) {
         case WriteCommand.setData:
           if (task.merge != null) {
-            task.document.set(task.data, SetOptions(merge: task.merge));
+            task.document!.set(task.data!, SetOptions(merge: task.merge));
           } else {
-            task.document.set(task.data);
+            task.document!.set(task.data!);
           }
           break;
         case WriteCommand.updateData:
-          task.document.update(task.data);
+          task.document!.update(task.data!);
           break;
         case WriteCommand.delete:
-          task.document.delete();
+          task.document!.delete();
           break;
       }
     }

--- a/lib/src/mock_write_batch.dart
+++ b/lib/src/mock_write_batch.dart
@@ -34,19 +34,19 @@ class MockWriteBatch extends Mock implements WriteBatch {
   @override
   Future<void> commit() {
     for (final task in tasks) {
-      switch (task.command!) {
+      switch (task.command) {
         case WriteCommand.setData:
           if (task.merge != null) {
-            task.document!.set(task.data!, SetOptions(merge: task.merge));
+            task.document.set(task.data!, SetOptions(merge: task.merge));
           } else {
-            task.document!.set(task.data!);
+            task.document.set(task.data!);
           }
           break;
         case WriteCommand.updateData:
-          task.document!.update(task.data!);
+          task.document.update(task.data!);
           break;
         case WriteCommand.delete:
-          task.document!.delete();
+          task.document.delete();
           break;
       }
     }

--- a/lib/src/write_task.dart
+++ b/lib/src/write_task.dart
@@ -9,8 +9,10 @@ enum WriteCommand {
 }
 
 class WriteTask {
-  WriteCommand? command;
-  DocumentReference? document;
+  late WriteCommand command;
+  late DocumentReference document;
+  // Is null if command is delete.
   Map<String, dynamic>? data;
+  // Is defined only for setData.
   bool? merge;
 }

--- a/lib/src/write_task.dart
+++ b/lib/src/write_task.dart
@@ -9,8 +9,8 @@ enum WriteCommand {
 }
 
 class WriteTask {
-  WriteCommand command;
-  DocumentReference document;
-  Map<String, dynamic> data;
-  bool merge;
+  WriteCommand? command;
+  DocumentReference? document;
+  Map<String, dynamic>? data;
+  bool? merge;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: cloud_firestore_mocks
 description: Fake implementation of Cloud Firestore. Use this package to write unit tests involving Cloud Firestore.
-version: 0.7.1
+version: 0.8.0
 homepage: http://blog.wafrat.com
 repository: https://github.com/atn832/cloud_firestore_mocks
 
 environment:
-  sdk: ">=2.9.1 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -14,13 +14,11 @@ dependencies:
   cloud_firestore_platform_interface: ^4.0.0
   collection: ^1.14.13
   plugin_platform_interface: ^2.0.0
-  mockito: ^4.1.1
+  mockito: ^5.0.0
   quiver: ^3.0.0
 
 dev_dependencies:
   flutter_test:
-    sdk: flutter
-  flutter_driver:
     sdk: flutter
   pedantic: ^1.9.0
   test: ^1.15.2

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -60,7 +60,7 @@ void main() {
   });
 
   group('adding data through collection reference', () {
-    MockFirestoreInstance instance;
+    late MockFirestoreInstance instance;
     setUp(() {
       instance = MockFirestoreInstance();
     });
@@ -213,7 +213,8 @@ void main() {
 
     final friendsFriends = documentReference.parent;
     final bbb = friendsFriends.parent;
-    final friends = bbb.parent;
+    expect(bbb, isNotNull);
+    final friends = bbb!.parent;
     final bbbSibling = friends.doc('bbb-sibling');
     expect(bbbSibling.path, 'users/aaa/friends/bbb-sibling');
   });
@@ -224,7 +225,9 @@ void main() {
         instance.collection('users').doc('aaa').collection('friends');
 
     expect(documentReference.firestore, instance);
-    expect(documentReference.parent.firestore, instance);
+    final parent = documentReference.parent;
+    expect(parent, isNotNull);
+    expect(parent!.firestore, instance);
   });
 
   test('Document reference equality', () async {
@@ -371,7 +374,9 @@ void main() {
       await firestore.doc('root/foo').set({'flower': 'rose'});
       await firestore.doc('root/foo').set({'flower': FieldValue.delete()});
       final document = await firestore.doc('root/foo').get();
-      expect(document.data().isEmpty, equals(true));
+      final data = document.data();
+      expect(data, isNotNull);
+      expect(data!.isEmpty, equals(true));
     });
 
     test('FieldValue.serverTimestamp() sets the time', () async {
@@ -932,8 +937,8 @@ void main() {
     });
 
     final eve = await instance.collection('users').doc(uid).get();
-    eve.data()['name'] = 'John';
-    eve.data()['friends'][0] = 'Superman';
+    eve.data()!['name'] = 'John';
+    eve.data()!['friends'][0] = 'Superman';
 
     expect(eve.get('name'), isNot('John')); // nothing changed
     expect(eve.get('friends'), equals(['Alice', 'Bob'])); // nothing changed

--- a/test/document_snapshot_matcher.dart
+++ b/test/document_snapshot_matcher.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 
 class DocumentSnapshotMatcher implements Matcher {
   // This may be null if no need to match ID
-  final String _documentId;
+  final String? _documentId;
   final Map<String, dynamic> _data;
 
   DocumentSnapshotMatcher(this._documentId, this._data);


### PR DESCRIPTION
Support null-safety.

I had to temporarily disable integration tests by removing the dependency to flutter_driver for it to work. Otherwise I get dependency errors on `flutter pub get`:

```
[cloud_firestore_mocks] flutter pub get
Running "flutter pub get" in cloud_firestore_mocks...           
Because analyzer >=1.0.0 depends on args ^2.0.0 and every version of flutter_driver from sdk depends on args 1.6.0, analyzer >=1.0.0 is incompatible with flutter_driver from sdk.

And because mockito >=5.0.0 depends on analyzer ^1.0.0, flutter_driver from sdk is incompatible with mockito >=5.0.0.

So, because cloud_firestore_mocks depends on both mockito ^5.0.0 and flutter_driver any from sdk, version solving failed.
pub get failed (1; So, because cloud_firestore_mocks depends on both mockito ^5.0.0 and flutter_driver any from sdk, version solving failed.)
exit code 1
```

I will restore flutter_driver after flutter_driver has updated its dependencies.

Fixes #142. Fixes #146.