### PR TITLE
Fix Query Snapshot To Return a Non Nullable Type

### DIFF
--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -12,7 +12,7 @@ class MockQueryDocumentSnapshot extends MockDocumentSnapshot
   bool get exists => true;
 
   @override
-    Map<String, dynamic> data() {
+  Map<String, dynamic> data() {
     return super.data()!;
   }
 }

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -7,4 +7,12 @@ class MockQueryDocumentSnapshot extends MockDocumentSnapshot
   MockQueryDocumentSnapshot(DocumentReference reference, String documentId,
       Map<String, dynamic>? document)
       : super(reference, documentId, document, true);
+
+  @override
+  bool get exists => true;
+
+  @override
+    Map<String, dynamic> data() {
+    return super.data()!;
+  }
 }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -181,7 +181,7 @@ void main() {
 
     final query = instance.collection('users').orderBy(FieldPath.documentId);
     query.snapshots().listen(expectAsync1(
-      (QuerySnapshot event) {
+      (event) {
         expect(event.docs.first.id, ('1'));
         expect(event.docs[1].id, ('2'));
         expect(event.docs[2].id, ('3'));

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -175,14 +175,13 @@ void main() {
 
   test('orderBy returns documents sorted by documentID', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').doc('3').set({});
-    await instance.collection('users').doc('2').set({});
-    await instance.collection('users').doc('1').set({});
+    await instance.collection('users').doc('3').set({'value': 3});
+    await instance.collection('users').doc('2').set({'value': 2});
+    await instance.collection('users').doc('1').set({'value': 1});
 
     final query = instance.collection('users').orderBy(FieldPath.documentId);
-
     query.snapshots().listen(expectAsync1(
-      (event) {
+      (QuerySnapshot event) {
         expect(event.docs.first.id, ('1'));
         expect(event.docs[1].id, ('2'));
         expect(event.docs[2].id, ('3'));
@@ -327,9 +326,9 @@ void main() {
 
   test('where with FieldPath.documentID', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').doc('1').set({});
-    await instance.collection('users').doc('2').set({});
-    await instance.collection('users').doc('3').set({});
+    await instance.collection('users').doc('1').set({'value': 1});
+    await instance.collection('users').doc('2').set({'value': 2});
+    await instance.collection('users').doc('3').set({'value': 3});
 
     final snapshot = await instance
         .collection('users')

--- a/test_driver/cloud_firestore_behaviors.dart
+++ b/test_driver/cloud_firestore_behaviors.dart
@@ -44,7 +44,7 @@ void main() {
       await doc.delete();
 
       expect(documentId.length, _test.greaterThanOrEqualTo(20));
-      expect(result.data()['message'], 'hello firestore');
+      expect(result.data()!['message'], 'hello firestore');
     });
 
     ftest('Invalidate bad values', (firestore) async {
@@ -134,7 +134,7 @@ void main() {
       await doc.delete();
 
       expect(result.id, documentId);
-      expect(result.data()['message'], 'hello firestore');
+      expect(result.data()!['message'], 'hello firestore');
       final map1 = result.data()['nested1'];
       expect(map1['field2'], 2);
       final map2 = map1['nested2'];
@@ -245,7 +245,7 @@ void main() {
       await doc.delete();
 
       expect(result.get('created_at'), _test.isA<Timestamp>());
-      final createdAt = (result.data()['created_at'] as Timestamp).toDate();
+      final createdAt = (result.data()!['created_at'] as Timestamp).toDate();
 
       // The conversion between Dart's DateTime and Firestore's Timestamp is not a
       // loss-less conversion. For example, asserting createdAt equals to currentDateTime
@@ -336,7 +336,7 @@ void main() {
 
       // At the time the snapshot was created, the value was 'old'
       expect(snapshot.get('foo'), 'old');
-      final nested = snapshot.data()['nested'];
+      final nested = snapshot.data()!['nested'];
       final nestedData = nested['data'];
       expect(nestedData['message'], 'old nested data');
     });
@@ -381,7 +381,7 @@ void main() {
       final result = await firestore.runTransaction((tx) async {
         final snapshotFoo = await tx.get(foo);
 
-        tx.set(foo, {'name': snapshotFoo.data()['name'] + 'o'});
+        tx.set(foo, {'name': snapshotFoo.data()!['name'] + 'o'});
         // not returning a map
       });
       expect(result, _test.isEmpty);

--- a/test_driver/cloud_firestore_behaviors.dart
+++ b/test_driver/cloud_firestore_behaviors.dart
@@ -44,7 +44,7 @@ void main() {
       await doc.delete();
 
       expect(documentId.length, _test.greaterThanOrEqualTo(20));
-      expect(result.data()!['message'], 'hello firestore');
+      expect(result.data()['message'], 'hello firestore');
     });
 
     ftest('Invalidate bad values', (firestore) async {
@@ -134,7 +134,7 @@ void main() {
       await doc.delete();
 
       expect(result.id, documentId);
-      expect(result.data()!['message'], 'hello firestore');
+      expect(result.data()['message'], 'hello firestore');
       final map1 = result.data()['nested1'];
       expect(map1['field2'], 2);
       final map2 = map1['nested2'];
@@ -245,7 +245,7 @@ void main() {
       await doc.delete();
 
       expect(result.get('created_at'), _test.isA<Timestamp>());
-      final createdAt = (result.data()!['created_at'] as Timestamp).toDate();
+      final createdAt = (result.data()['created_at'] as Timestamp).toDate();
 
       // The conversion between Dart's DateTime and Firestore's Timestamp is not a
       // loss-less conversion. For example, asserting createdAt equals to currentDateTime
@@ -336,7 +336,7 @@ void main() {
 
       // At the time the snapshot was created, the value was 'old'
       expect(snapshot.get('foo'), 'old');
-      final nested = snapshot.data()!['nested'];
+      final nested = snapshot.data()['nested'];
       final nestedData = nested['data'];
       expect(nestedData['message'], 'old nested data');
     });
@@ -381,7 +381,7 @@ void main() {
       final result = await firestore.runTransaction((tx) async {
         final snapshotFoo = await tx.get(foo);
 
-        tx.set(foo, {'name': snapshotFoo.data()!['name'] + 'o'});
+        tx.set(foo, {'name': snapshotFoo.data()['name'] + 'o'});
         // not returning a map
       });
       expect(result, _test.isEmpty);


### PR DESCRIPTION
Fix Query Snapshot that returns a non nullable type from this PR https://github.com/FirebaseExtended/flutterfire/pull/5476

I tested this by using in my pubspec.yaml file and works 
```
  cloud_firestore_mocks: 
    git:
      url: git@github.com:lyledean1/cloud_firestore_mocks.git
      ref: fix-mocks
```