### PR TITLE
Fix MockDocumentSnapshot#data method signature and improve test usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.8.1
+
+- fixed `QueryDocumentSnapshot.data`'s signature change introduced in firestore 1.0.4. Thank you [lyledean1](https://github.com/lyledean1)!
+- fixed the compilation issues in integration tests.
+
 ## 0.8.0
 
 - migrate to null safety.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,5 +10,8 @@ include: package:pedantic/analysis_options.yaml
 #     - camel_case_types
 
 analyzer:
+  errors:
+    # TODO(https://github.com/atn832/cloud_firestore_mocks/issues/157): remove this exception when the null-safe update to flutter_driver is released (Flutter 2.10).
+    import_of_legacy_library_into_null_safe: ignore
 #   exclude:
 #     - path/to/excluded/files/**

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
-        classpath 'com.google.gms:google-services:4.3.0'
+        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.google.gms:google-services:4.3.3'
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,4 @@
+analyzer:
+  errors:
+    # TODO(https://github.com/atn832/cloud_firestore_mocks/issues/157): remove this exception when the null-safe update to flutter_driver is released (Flutter 2.10).
+    import_of_legacy_library_into_null_safe: ignore

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,7 +28,7 @@ Future<void> main() async {
 }
 
 class MessageList extends StatelessWidget {
-  MessageList({this.firestore});
+  MessageList({required this.firestore});
 
   final FirebaseFirestore firestore;
 
@@ -37,12 +37,13 @@ class MessageList extends StatelessWidget {
     return StreamBuilder<QuerySnapshot>(
       stream: firestore.collection('messages').snapshots(),
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
-        if (!snapshot.hasData) return const Text('Loading...');
-        final messageCount = snapshot.data.docs.length;
+        final data = snapshot.data;
+        if (!snapshot.hasData || data == null) return const Text('Loading...');
+        final messageCount = data.docs.length;
         return ListView.builder(
           itemCount: messageCount,
           itemBuilder: (_, int index) {
-            final document = snapshot.data.docs[index];
+            final document = data.docs[index];
             final dynamic message = document.get('message');
             return ListTile(
               title: Text(
@@ -58,7 +59,7 @@ class MessageList extends StatelessWidget {
 }
 
 class MyHomePage extends StatelessWidget {
-  MyHomePage({this.firestore});
+  MyHomePage({required this.firestore});
 
   final FirebaseFirestore firestore;
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,9 +11,16 @@ dependencies:
   firebase_core: ^1.0.0
 
 dev_dependencies:
+  flutter_driver:
+    sdk: flutter
   test: any
   cloud_firestore_mocks:
     path: ../
+
+# Force flutter_driver to use crypto 3 and convert 3.
+dependency_overrides:
+  crypto: ^3.0.0
+  convert: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -11,16 +11,9 @@ dependencies:
   firebase_core: ^1.0.0
 
 dev_dependencies:
-  flutter_driver:
-    sdk: flutter
   test: any
   cloud_firestore_mocks:
     path: ../
-
-# Force flutter_driver to use crypto 3 and convert 3.
-dependency_overrides:
-  crypto: ^3.0.0
-  convert: ^3.0.0
 
 flutter:
   uses-material-design: true

--- a/example/test_driver/cloud_firestore.dart
+++ b/example/test_driver/cloud_firestore.dart
@@ -11,8 +11,8 @@ void main() {
   tearDownAll(() => completer.complete(null));
 
   group('$FirebaseFirestore', () {
-    FirebaseFirestore firestore;
-    FirebaseFirestore firestoreWithSettings;
+    late FirebaseFirestore firestore;
+    late FirebaseFirestore firestoreWithSettings;
 
     setUp(() async {
       final firebaseOptions = const FirebaseOptions(
@@ -146,7 +146,7 @@ void main() {
       final dynamic result = await firestore.runTransaction(
         (Transaction tx) async {
           final snapshot = await tx.get(ref);
-          final updatedData = Map<String, dynamic>.from(snapshot.data());
+          final updatedData = Map<String, dynamic>.from(snapshot.data()!);
           updatedData['message'] = 'testing2';
           tx.update(ref, updatedData);
           return updatedData;

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart'
     as firestore_interface;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:mockito/mockito.dart';
 
@@ -22,6 +23,14 @@ class MockFirestoreInstance extends Mock implements FirebaseFirestore {
   final Set<String> _savedDocumentPaths = <String>{};
   MockFirestoreInstance() {
     _setupFieldValueFactory();
+  }
+
+  /// Clears the state
+  @visibleForTesting
+  void reset() {
+    _root.clear();
+    _docsData.clear();
+    _snapshotStreamControllerRoot.clear();
   }
 
   @override

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -20,14 +20,19 @@ class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
   String get id => _id;
 
   @override
-  dynamic get(dynamic key) => _document![key];
+  dynamic get(dynamic key) {
+    if (_isComposedKey(key)) {
+      return getComposedKeyValue(key);
+    }
+    return _document![key];
+  }
 
   @override
-  Map<String, dynamic>? data() {
+  Map<String, dynamic> data() {
     if (_exists) {
       return deepCopy(_document);
     } else {
-      return null;
+      return {};
     }
   }
 
@@ -39,4 +44,17 @@ class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
 
   @override
   SnapshotMetadata get metadata => _metadata;
+
+  bool _isComposedKey(String key) {
+    return key.contains('.');
+  }
+
+  dynamic getComposedKeyValue(String key) {
+    var groups = key.split('.');
+    dynamic value = _document!;
+    for (var group in groups) {
+      value = value[group];
+    }
+    return value;
+  }
 }

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -7,4 +7,12 @@ class MockQueryDocumentSnapshot extends MockDocumentSnapshot
   MockQueryDocumentSnapshot(DocumentReference reference, String documentId,
       Map<String, dynamic>? document)
       : super(reference, documentId, document, true);
+
+  @override
+  bool get exists => true;
+
+  @override
+  Map<String, dynamic> data() {
+    return super.data()!;
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,5 +20,12 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
   pedantic: ^1.9.0
   test: ^1.15.2
+
+# Force flutter_driver to use crypto 3 and convert 3.
+dependency_overrides:
+  crypto: ^3.0.0
+  convert: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,12 +20,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_driver:
-    sdk: flutter
   pedantic: ^1.9.0
   test: ^1.15.2
-
-# Force flutter_driver to use crypto 3 and convert 3.
-dependency_overrides:
-  crypto: ^3.0.0
-  convert: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_firestore_mocks
 description: Fake implementation of Cloud Firestore. Use this package to write unit tests involving Cloud Firestore.
-version: 0.8.0
+version: 0.8.1
 homepage: http://blog.wafrat.com
 repository: https://github.com/atn832/cloud_firestore_mocks
 

--- a/test/cloud_firestore_mocks_test.dart
+++ b/test/cloud_firestore_mocks_test.dart
@@ -310,7 +310,7 @@ void main() {
     expect(nested['k1'], 'v1');
   });
 
-  test('Nonexistent document should have null data', () async {
+  test('Nonexistent document should have empty data', () async {
     final nonExistentId = 'nonExistentId';
     final instance = MockFirestoreInstance();
 
@@ -319,7 +319,7 @@ void main() {
     expect(snapshot1, isNotNull);
     expect(snapshot1.id, nonExistentId);
     // data field should be null before the document is saved
-    expect(snapshot1.data(), isNull);
+    expect(snapshot1.data(), {});
   });
 
   test('Snapshots returns a Stream of Snapshots upon each change', () async {
@@ -1035,5 +1035,17 @@ void main() {
             'gift': 'Princess dress',
           })
         ])));
+  });
+
+  test('Reset state for testing', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('users').doc(uid).set({
+      'username': 'Bob',
+    });
+
+    instance.reset();
+
+    final users = await instance.collection('users').get();
+    expect(users.docs.isEmpty, equals(true));
   });
 }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -175,12 +175,11 @@ void main() {
 
   test('orderBy returns documents sorted by documentID', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').doc('3').set({});
-    await instance.collection('users').doc('2').set({});
-    await instance.collection('users').doc('1').set({});
+    await instance.collection('users').doc('3').set({'value': 3});
+    await instance.collection('users').doc('2').set({'value': 2});
+    await instance.collection('users').doc('1').set({'value': 1});
 
     final query = instance.collection('users').orderBy(FieldPath.documentId);
-
     query.snapshots().listen(expectAsync1(
       (event) {
         expect(event.docs.first.id, ('1'));
@@ -327,9 +326,9 @@ void main() {
 
   test('where with FieldPath.documentID', () async {
     final instance = MockFirestoreInstance();
-    await instance.collection('users').doc('1').set({});
-    await instance.collection('users').doc('2').set({});
-    await instance.collection('users').doc('3').set({});
+    await instance.collection('users').doc('1').set({'value': 1});
+    await instance.collection('users').doc('2').set({'value': 2});
+    await instance.collection('users').doc('3').set({'value': 3});
 
     final snapshot = await instance
         .collection('users')

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -324,6 +324,31 @@ void main() {
         }));
   });
 
+  test('Where clause resolves composed keys', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('contestants').add({
+      'name': 'Alice',
+      'country': 'USA',
+      'skills': {'cycling': '1', 'running': ''}
+    });
+
+    instance
+        .collection('contestants')
+        .where('skills.cycling', isGreaterThan: '')
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+      expect(snapshot.docs.length, equals(1));
+    }));
+
+    instance
+        .collection('contestants')
+        .where('skills.running', isGreaterThan: '')
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+      expect(snapshot.docs.length, equals(0));
+    }));
+  });
+
   test('where with FieldPath.documentID', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('users').doc('1').set({'value': 1});

--- a/test_driver/cloud_firestore_behaviors.dart
+++ b/test_driver/cloud_firestore_behaviors.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert' show utf8;
+import 'dart:typed_data';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
@@ -44,7 +45,9 @@ void main() {
       await doc.delete();
 
       expect(documentId.length, _test.greaterThanOrEqualTo(20));
-      expect(result.data()['message'], 'hello firestore');
+      final data = result.data();
+      expect(data, isNotNull);
+      expect(data!['message'], 'hello firestore');
     });
 
     ftest('Invalidate bad values', (firestore) async {
@@ -134,8 +137,8 @@ void main() {
       await doc.delete();
 
       expect(result.id, documentId);
-      expect(result.data()['message'], 'hello firestore');
-      final map1 = result.data()['nested1'];
+      expect(result.data()!['message'], 'hello firestore');
+      final map1 = result.data()!['nested1'];
       expect(map1['field2'], 2);
       final map2 = map1['nested2'];
       expect(map2['field3'], 3);
@@ -245,7 +248,9 @@ void main() {
       await doc.delete();
 
       expect(result.get('created_at'), _test.isA<Timestamp>());
-      final createdAt = (result.data()['created_at'] as Timestamp).toDate();
+      final data = result.data();
+      expect(data, isNotNull);
+      final createdAt = (data!['created_at'] as Timestamp).toDate();
 
       // The conversion between Dart's DateTime and Firestore's Timestamp is not a
       // loss-less conversion. For example, asserting createdAt equals to currentDateTime
@@ -336,7 +341,9 @@ void main() {
 
       // At the time the snapshot was created, the value was 'old'
       expect(snapshot.get('foo'), 'old');
-      final nested = snapshot.data()['nested'];
+      final data = snapshot.data();
+      expect(data, isNotNull);
+      final nested = data!['nested'];
       final nestedData = nested['data'];
       expect(nestedData['message'], 'old nested data');
     });
@@ -381,7 +388,7 @@ void main() {
       final result = await firestore.runTransaction((tx) async {
         final snapshotFoo = await tx.get(foo);
 
-        tx.set(foo, {'name': snapshotFoo.data()['name'] + 'o'});
+        tx.set(foo, {'name': snapshotFoo.data()!['name'] + 'o'});
         // not returning a map
       });
       expect(result, _test.isEmpty);
@@ -478,7 +485,7 @@ void main() {
           'DateTime': currentTime,
           'Timestamp': timestamp,
           'GeoPoint': geoPoint,
-          'Blob': Blob(utf8.encode('bytes')),
+          'Blob': Blob(Uint8List.fromList(utf8.encode('bytes'))),
         };
       });
       expect(result['null'], null);
@@ -498,7 +505,7 @@ void main() {
                   t1.difference(t2).inMilliseconds));
       expect(result['Timestamp'], timestamp);
       expect(result['GeoPoint'], geoPoint);
-      expect(result['Blob'], Blob(utf8.encode('bytes')));
+      expect(result['Blob'], Blob(Uint8List.fromList(utf8.encode('bytes'))));
     });
   });
 

--- a/test_driver/firestore_clients.dart
+++ b/test_driver/firestore_clients.dart
@@ -5,7 +5,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 Future<FirebaseFirestore> createFireStoreClient(
-    String appName, String host, bool sslEnabled) async {
+    String appName, String? host, bool sslEnabled) async {
   // This is from https://github.com/FirebaseExtended/flutterfire/blob/master/packages/cloud_firestore/cloud_firestore/example/test_driver/cloud_firestore.dart
   final firebaseOptions = const FirebaseOptions(
     appId: '1:79601577497:ios:5f2bcc6ba8cecddd',
@@ -28,7 +28,7 @@ Future<FirebaseFirestore> createFireStoreClient(
 }
 
 // Firestore instances to compare their behavior
-Map<String, Future<FirebaseFirestore>> firestoreFutures = {};
+Map<String, Future<FirebaseFirestore?>> firestoreFutures = {};
 
 typedef TestCase = Future<void> Function(FirebaseFirestore firestore);
 


### PR DESCRIPTION
Hi @atn832,

thanks a lot for providing these mocks.
When i tried to use them in one of my projects i just stumbled upon a few issues:

* data() in DocumentSnapshot returns a non-null value - the mock has overridden the method with a nullable return type. Therefore tests couldn't be run at all.
* There's no reset() method to clear the state in a tests setUp method
* Queries where the where conditions key included a maps key were not working (see MockDocumentSnapshot#get(key))
