### PR TITLE
Support queries using composite keys

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -20,7 +20,12 @@ class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
   String get id => _id;
 
   @override
-  dynamic get(dynamic key) => _document![key];
+  dynamic get(dynamic key) {
+    if (_isCompositeKey(key)) {
+      return getCompositeKeyValue(key);
+    }
+    return _document![key];
+  }
 
   @override
   Map<String, dynamic>? data() {
@@ -39,4 +44,17 @@ class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
 
   @override
   SnapshotMetadata get metadata => _metadata;
+
+  bool _isCompositeKey(String key) {
+    return key.contains('.');
+  }
+
+  dynamic getCompositeKeyValue(String key) {
+    final compositeKeyElements = key.split('.');
+    dynamic value = _document!;
+    for (final keyElement in compositeKeyElements) {
+      value = value[keyElement];
+    }
+    return value;
+  }
 }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -190,6 +190,39 @@ void main() {
     ));
   });
 
+  test('Where clause resolves composed keys', () async {
+    final instance = MockFirestoreInstance();
+    await instance.collection('contestants').add({
+      'name': 'Alice',
+      'country': 'USA',
+      'skills': {'cycling': '1', 'running': ''}
+    });
+
+    instance
+        .collection('contestants')
+        .where('skills.cycling', isGreaterThan: '')
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+      expect(snapshot.docs.length, equals(1));
+    }));
+
+    instance
+        .collection('contestants')
+        .where('skills.cycling', isEqualTo: '1')
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+      expect(snapshot.docs.length, equals(1));
+    }));
+
+    instance
+        .collection('contestants')
+        .where('skills.running', isGreaterThan: '')
+        .snapshots()
+        .listen(expectAsync1((QuerySnapshot snapshot) {
+      expect(snapshot.docs.length, equals(0));
+    }));
+  });
+
   test('arrayContains', () async {
     final instance = MockFirestoreInstance();
     await instance.collection('posts').add({


### PR DESCRIPTION
Hi @atn832,

this is the follow up of PR #155 which adds support for queries with composed keys.

When i tried writing some more tests, i noticed a few more minor issues:
* Queries with IsNull are not yet supported
* Queries with a composed key that does not exist (hence returns a null value) will fail as null is tried to cast to Comparable.
I have fixed them but i guess i should better put them in separate PRs as they are not only related to queries with composite keys?
Therefore some tests regarding the composite key feature are missing (query with a composite key that does not exist + query with isNull).

Regards,
Alex