### PR TITLE
Fix null pointer exception

### DIFF
--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -54,6 +54,7 @@ class MockDocumentSnapshot extends Mock implements DocumentSnapshot {
     dynamic value = _document!;
     for (final keyElement in compositeKeyElements) {
       value = value[keyElement];
+      if (value == null) return null;
     }
     return value;
   }

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -825,4 +825,31 @@ void main() {
     // Checks that isFromCache is false
     expect(snapshot.docs[0].metadata.isFromCache, equals(false));
   });
+
+  test('Query to check nested fields', () async {
+    // Simple user data missing nested map
+    final testData = {
+      'id': 22,
+      'reportBy': 'Ming',
+      // 'user': {
+      //   'name': 'Daniel',
+      //   'age': 23,
+      // },
+    };
+
+    final instance = MockFirestoreInstance();
+
+    // add data to users collection
+    await instance.collection('users').add(testData);
+
+    // make the query
+    final collectionReference = instance.collection('users');
+    final query = collectionReference.where('user.age', isEqualTo: 18);
+
+    // exec the query
+    final snapshot = await query.get();
+
+    // Checks that there is no docs returns
+    expect(snapshot.docs.length, 0);
+  });
 }


### PR DESCRIPTION
There is a null pointer exception when query using `where()` cause with nested fields where the top-level name is missing.

e.g: `collectionReference.where('user.age', isEqualTo: 18);`
This query will failed if `user` is null.