### PR TITLE
Support cloud_firestore 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0
+
+- migrated to Firestore 2.1.0.
+
 ## 0.8.3+1
 
 - fixed compile error.
@@ -26,11 +30,11 @@
 
 ## 0.7.0
 
-- migrate to Firestore 1.0.0. Thank you [Jouby](https://github.com/Jouby)!
+- migrated to Firestore 1.0.0. Thank you [Jouby](https://github.com/Jouby)!
 
 ## 0.6.0
 
-- migrate to Firestore 0.16.0.
+- migrated to Firestore 0.16.0.
 
 ## 0.5.2+1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.9.0
 
 - migrated to Firestore 2.1.0.
+- documented a compatibility table.
 
 ## 0.8.3+1
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ See more examples at [cloud_firestore_mocks/example/test/widget_test.dart](https
   - update numerical values with `FieldValue.increment`.
   - update arrays with `FieldValue.arrayUnion` and `FieldValue.arrayRemove`.
 
+## Compatibility table
+
+| cloud_firestore | cloud_firestore_mocks |
+|-----------------|-----------------------|
+| 2.1.0           | 0.9.0                 |
+| 1.0.0           | 0.7.0                 |
+| 0.16.0          | 0.6.0                 |
+| 0.14.0          | 0.5.0                 |
+| 0.13.1+1        | 0.4.1                 |
+| 0.13.0+1        | 0.2.5                 |
+| ^0.12.9+6       | 0.2.0                 |
+
 ## Features and bugs
 
 Please file feature requests and bugs at the issue tracker.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^1.0.0
+  cloud_firestore: ^2.1.0
   firebase_core: ^1.0.0
 
 dev_dependencies:

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -159,11 +159,8 @@ class _DummyTransaction implements Transaction {
   }
 
   @override
-  Transaction set<T>(
-    DocumentReference<T> documentReference,
-    T data, [
-    SetOptions? options,
-  ]) {
+  Transaction set<T>(DocumentReference<T> documentReference, T data,
+      [SetOptions? options]) {
     _foundWrite = true;
     documentReference.set(data);
     return this;

--- a/lib/src/cloud_firestore_mocks_base.dart
+++ b/lib/src/cloud_firestore_mocks_base.dart
@@ -24,7 +24,7 @@ class MockFirestoreInstance implements FirebaseFirestore {
   }
 
   @override
-  CollectionReference collection(String path) {
+  CollectionReference<Map<String, dynamic>> collection(String path) {
     final segments = path.split('/');
     assert(segments.length % 2 == 1,
         'Invalid document reference. Collection references must have an odd number of segments');
@@ -33,7 +33,8 @@ class MockFirestoreInstance implements FirebaseFirestore {
   }
 
   @override
-  CollectionReference collectionGroup(String collectionId) {
+  CollectionReference<Map<String, dynamic>> collectionGroup(
+      String collectionId) {
     assert(!collectionId.contains('/'), 'Collection ID should not contain "/"');
     return MockCollectionReference(
       this,
@@ -47,7 +48,7 @@ class MockFirestoreInstance implements FirebaseFirestore {
   }
 
   @override
-  DocumentReference doc(String path) {
+  DocumentReference<Map<String, dynamic>> doc(String path) {
     final segments = path.split('/');
     // The actual behavior of Firestore for an invalid number of segments
     // differs by platforms. This library imitates it with assert.
@@ -131,7 +132,8 @@ class _DummyTransaction implements Transaction {
   bool _foundWrite = false;
 
   @override
-  Future<DocumentSnapshot> get(DocumentReference documentReference) {
+  Future<DocumentSnapshot<T>> get<T extends Object?>(
+      DocumentReference<T> documentReference) {
     if (_foundWrite) {
       throw PlatformException(
           code: '3',
@@ -157,9 +159,11 @@ class _DummyTransaction implements Transaction {
   }
 
   @override
-  Transaction set(
-      DocumentReference documentReference, Map<String, dynamic> data,
-      [SetOptions? options]) {
+  Transaction set<T>(
+    DocumentReference<T> documentReference,
+    T data, [
+    SetOptions? options,
+  ]) {
     _foundWrite = true;
     documentReference.set(data);
     return this;

--- a/lib/src/mock_document_change.dart
+++ b/lib/src/mock_document_change.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-class MockDocumentChange implements DocumentChange {
-  final DocumentSnapshot _document;
+class MockDocumentChange<T extends Object?> implements DocumentChange<T> {
+  final DocumentSnapshot<T> _document;
   final DocumentChangeType _type;
   final int _oldIndex;
   final int _newIndex;
@@ -24,5 +24,5 @@ class MockDocumentChange implements DocumentChange {
   int get newIndex => _newIndex;
 
   @override
-  DocumentSnapshot get doc => _document;
+  DocumentSnapshot<T> get doc => _document;
 }

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -54,10 +54,20 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
     final segmentLength = segments.length;
     final parentSegments = segments.sublist(0, segmentLength - 1);
     final parentPath = parentSegments.join('/');
-    // Required because Firestore returns a
+    final parentCollection = _firestore.collection(parentPath);
+    if (parentCollection is! CollectionReference<T>) {
+      throw UnimplementedError();
+    }
+    // The compiler still requires a cast, despite
+    // https://dart.dev/null-safety/understanding-null-safety#reachability-analysis.
+    // Without a cast, the compiler throws this error:
+    // > A value of type 'CollectionReference<Map<String, dynamic>>' can't be
+    // > returned from the function 'parent' because it has a return type of
+    // > 'CollectionReference<T>'.
+    // Just like FirebaseFirestore.collection, MockFirestoreInstance returns a
     // CollectionReference<Map<String, dynamic>>. See
     // https://pub.dev/documentation/cloud_firestore/2.1.0/cloud_firestore/FirebaseFirestore/collection.html.
-    return _firestore.collection(parentPath) as CollectionReference<T>;
+    return parentCollection as CollectionReference<T>;
   }
 
   @override

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -4,6 +4,8 @@ import 'package:cloud_firestore_mocks/src/util.dart';
 
 import 'util.dart';
 
+// Intentional implementation of DocumentSnapshot.
+// ignore: subtype_of_sealed_class
 class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
   final String _id;
   final Map<String, dynamic>? _document;

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -4,15 +4,14 @@ import 'package:cloud_firestore_mocks/src/util.dart';
 
 import 'util.dart';
 
-class MockDocumentSnapshot implements DocumentSnapshot {
+class MockDocumentSnapshot<T extends Object?> implements DocumentSnapshot<T> {
   final String _id;
   final Map<String, dynamic>? _document;
   final bool _exists;
-  final DocumentReference _reference;
+  final DocumentReference<T> _reference;
   final MockSnapshotMetadata _metadata = MockSnapshotMetadata();
 
-  MockDocumentSnapshot(
-      this._reference, this._id, Map<String, dynamic>? document, this._exists)
+  MockDocumentSnapshot(this._reference, this._id, T? document, this._exists)
       : _document = deepCopy(document);
 
   @override
@@ -27,7 +26,7 @@ class MockDocumentSnapshot implements DocumentSnapshot {
   }
 
   @override
-  Map<String, dynamic>? data() {
+  T? data() {
     if (_exists) {
       return deepCopy(_document);
     } else {
@@ -39,7 +38,7 @@ class MockDocumentSnapshot implements DocumentSnapshot {
   bool get exists => _exists;
 
   @override
-  DocumentReference get reference => _reference;
+  DocumentReference<T> get reference => _reference;
 
   @override
   SnapshotMetadata get metadata => _metadata;

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -180,8 +180,13 @@ class MockQuery<T extends Object?> implements Query<T> {
       var res;
       for (var i = 0; i < values.length; i++) {
         var index = docs.sublist(res ?? 0).indexWhere((doc) {
-          if (doc.data() == null) return false;
-          final mapData = doc.data()! as Map;
+          if (doc.data() == null) {
+            return false;
+          }
+          final mapData = doc.data();
+          if (mapData is! Map) {
+            throw UnimplementedError();
+          }
           final docValue = mapData[orderByKeys[i]];
           return docValue == values[i];
         });

--- a/lib/src/mock_query.dart
+++ b/lib/src/mock_query.dart
@@ -406,13 +406,15 @@ class QuerySnapshotStreamManager {
     }
   }
 
-  void register(MockQuery query) {
+  void register<T>(MockQuery<T> query) {
     final path = _retrieveParentPath(query);
     if (_streamCache.containsKey(path)) {
       _streamCache[path]!.putIfAbsent(
-          query, () => StreamController<QuerySnapshot>.broadcast());
+          query, () => StreamController<QuerySnapshot<T>>.broadcast());
     } else {
-      _streamCache[path] = {query: StreamController<QuerySnapshot>.broadcast()};
+      _streamCache[path] = {
+        query: StreamController<QuerySnapshot<T>>.broadcast()
+      };
     }
   }
 
@@ -433,8 +435,6 @@ class QuerySnapshotStreamManager {
     // `register(query)` beforehand, so pathCache should never be null.
     assert(pathCache != null);
     final streamController = pathCache![query]!;
-    print(streamController.runtimeType);
-    print(T);
     if (streamController is! StreamController<QuerySnapshot<T>>) {
       throw UnimplementedError();
     }

--- a/lib/src/mock_query_document_snapshot.dart
+++ b/lib/src/mock_query_document_snapshot.dart
@@ -2,17 +2,18 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'mock_document_snapshot.dart';
 
-class MockQueryDocumentSnapshot extends MockDocumentSnapshot
-    implements QueryDocumentSnapshot {
-  MockQueryDocumentSnapshot(DocumentReference reference, String documentId,
-      Map<String, dynamic>? document)
+// ignore: subtype_of_sealed_class
+class MockQueryDocumentSnapshot<T extends Object?>
+    extends MockDocumentSnapshot<T> implements QueryDocumentSnapshot<T> {
+  MockQueryDocumentSnapshot(
+      DocumentReference<T> reference, String documentId, T? document)
       : super(reference, documentId, document, true);
 
   @override
   bool get exists => true;
 
   @override
-  Map<String, dynamic> data() {
+  T data() {
     return super.data()!;
   }
 }

--- a/lib/src/mock_query_snapshot.dart
+++ b/lib/src/mock_query_snapshot.dart
@@ -3,16 +3,16 @@ import 'package:cloud_firestore_mocks/src/mock_document_change.dart';
 
 import 'mock_query_document_snapshot.dart';
 
-class MockQuerySnapshot implements QuerySnapshot {
-  final List<DocumentSnapshot> _documents;
+class MockQuerySnapshot<T extends Object?> implements QuerySnapshot<T> {
+  final List<DocumentSnapshot<T>> _documents;
 
-  final List<DocumentChange> _documentChanges = <DocumentChange>[];
+  final List<DocumentChange<T>> _documentChanges = <DocumentChange<T>>[];
 
   MockQuerySnapshot(this._documents) {
     // TODO: support another change type (removed, modified).
     // ref: https://pub.dev/documentation/cloud_firestore_platform_interface/latest/cloud_firestore_platform_interface/DocumentChangeType-class.html
     _documents.asMap().forEach((index, document) {
-      _documentChanges.add(MockDocumentChange(
+      _documentChanges.add(MockDocumentChange<T>(
         document,
         DocumentChangeType.added,
         oldIndex:
@@ -23,14 +23,14 @@ class MockQuerySnapshot implements QuerySnapshot {
   }
 
   @override
-  List<QueryDocumentSnapshot> get docs => _documents
+  List<QueryDocumentSnapshot<T>> get docs => _documents
       .map(
         (doc) => MockQueryDocumentSnapshot(doc.reference, doc.id, doc.data()),
       )
       .toList();
 
   @override
-  List<DocumentChange> get docChanges => _documentChanges;
+  List<DocumentChange<T>> get docChanges => _documentChanges;
 
   @override
   // TODO: implement metadata

--- a/lib/src/mock_write_batch.dart
+++ b/lib/src/mock_write_batch.dart
@@ -6,13 +6,16 @@ class MockWriteBatch implements WriteBatch {
   List<WriteTask> tasks = [];
 
   @override
-  void set(DocumentReference document, Map<String, dynamic> data,
-      [SetOptions? setOptions]) {
-    tasks.add(WriteTask()
+  void set<T>(
+    DocumentReference<T> document,
+    T data, [
+    SetOptions? options,
+  ]) {
+    tasks.add(WriteTask<T>()
       ..command = WriteCommand.setData
       ..document = document
       ..data = data
-      ..merge = setOptions?.merge);
+      ..merge = options?.merge);
   }
 
   @override

--- a/lib/src/write_task.dart
+++ b/lib/src/write_task.dart
@@ -8,11 +8,11 @@ enum WriteCommand {
   delete,
 }
 
-class WriteTask {
+class WriteTask<T> {
   late WriteCommand command;
   late DocumentReference document;
   // Is null if command is delete.
-  Map<String, dynamic>? data;
+  T? data;
   // Is defined only for setData.
   bool? merge;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_firestore_mocks
 description: Fake implementation of Cloud Firestore. Use this package to write unit tests involving Cloud Firestore.
-version: 0.8.3+1
+version: 0.9.0
 homepage: http://blog.wafrat.com
 repository: https://github.com/atn832/cloud_firestore_mocks
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^1.0.0
-  cloud_firestore_platform_interface: ^4.0.0
+  cloud_firestore: ^2.1.0
+  cloud_firestore_platform_interface: ^5.0.1
   collection: ^1.14.13
   plugin_platform_interface: ^2.0.0
   quiver: ^3.0.0

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -8,9 +8,8 @@ import 'query_snapshot_matcher.dart';
 
 const uid = 'abc';
 
-extension ToData on List<QueryDocumentSnapshot> {
-  List<Map<String, dynamic>?> toData() =>
-      map((snapshot) => snapshot.data()).toList();
+extension ToData<T> on List<QueryDocumentSnapshot<T>> {
+  List<T?> toData() => map((snapshot) => snapshot.data()).toList();
 }
 
 void main() {
@@ -272,7 +271,7 @@ void main() {
     final data =
         await firestore.collection('test').orderBy('nested.value').get();
     expect(data.docs.first.get('nested.value'), 2);
-    expect(data.docs.first.data()!['nested']['value'], 2);
+    expect(data.docs.first.data()['nested']['value'], 2);
   });
 
   test('Where clause resolves composed keys', () async {


### PR DESCRIPTION
As documented at https://firebase.flutter.dev/docs/firestore/2.0.0_migration/, it requires using Generics everywhere.

Fixes #163.

All unit tests for the library pass.

Unit tests for the example app and Analyzer fail because of #157.