### PR TITLE
Rename cloud_firestore_mocks to fake_cloud_firestore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.0.0
+
+Breaking change:
+
+- renamed the library to fake_cloud_firestore and MockFirestoreInstance to MockFirestoreInstance.
+
+### Migration notes
+
+In your pubspec.yaml file, replace `cloud_firestore_mocks: ^0.9.0` by `fake_cloud_firestore: ^1.0.0`.
+
+Then in your tests, replace:
+
+```dart
+import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+
+final firestore = MockFirestoreInstance();
+```
+
+By:
+
+```dart
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+
+final firestore = FakeFirebaseFirestore();
+```
+
 ## 0.9.0
 
 - migrated to Firestore 2.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 Breaking change:
 
-- renamed the library to fake_cloud_firestore and MockFirestoreInstance to MockFirestoreInstance.
+- renamed the library from cloud_firestore_mocks to fake_cloud_firestore
+- renamed `MockFirestoreInstance` to `FakeFirebaseFirestore`.
 
 ### Migration notes
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Cloud Firestore Mocks
-[![pub package](https://img.shields.io/pub/v/cloud_firestore_mocks.svg)](https://pub.dartlang.org/packages/cloud_firestore_mocks)
+[![pub package](https://img.shields.io/pub/v/fake_cloud_firestore.svg)](https://pub.dartlang.org/packages/fake_cloud_firestore)
 
 Fakes to write unit tests for Cloud Firestore. Instantiate a
-`MockFirestoreInstance`, then pass it around your project as if it were a
-`FirestoreInstance`. This fake acts like Firestore except it will only keep
+`FakeFirebaseFirestore`, then pass it around your project as if it were a
+`FirebaseFirestore`. This fake acts like Firestore except it will only keep
 the state in memory.
-To help debug, you can use `MockFirestoreInstance.dump()` to see what's in the
+To help debug, you can use `FakeFirebaseFirestore.dump()` to see what's in the
 fake database.
 This is useful to set up the state of your database, then check that your UI
 behaves the way you expect.
@@ -15,10 +15,10 @@ behaves the way you expect.
 ### A simple usage example
 
 ```dart
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 
 void main() {
-  final instance = MockFirestoreInstance();
+  final instance = FakeFirebaseFirestore();
   await instance.collection('users').add({
     'username': 'Bob',
   });
@@ -38,13 +38,13 @@ void main() {
 // }
 ```
 
-See more examples at [cloud_firestore_mocks/test/cloud_firestore_mocks_test.dart](https://github.com/atn832/cloud_firestore_mocks/blob/master/test/cloud_firestore_mocks_test.dart).
+See more examples at [fake_cloud_firestore/test/fake_cloud_firestore_test.dart](https://github.com/atn832/fake_cloud_firestore/blob/master/test/fake_cloud_firestore_test.dart).
 
 ### Usage in a UI test:
 
 ```dart
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:firestore_example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -54,7 +54,7 @@ const MessagesCollection = 'messages';
 void main() {
   testWidgets('shows messages', (WidgetTester tester) async {
     // Populate the mock database.
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     await firestore.collection(MessagesCollection).add({
       'message': 'Hello world!',
       'created_at': FieldValue.serverTimestamp(),
@@ -74,11 +74,11 @@ void main() {
 }
 ```
 
-See more examples at [cloud_firestore_mocks/example/test/widget_test.dart](https://github.com/atn832/cloud_firestore_mocks/blob/master/example/test/widget_test.dart).
+See more examples at [fake_cloud_firestore/example/test/widget_test.dart](https://github.com/atn832/fake_cloud_firestore/blob/master/example/test/widget_test.dart).
 
 ## Features
 
-- Dump the state of the mock firebase with `MockFirestoreInstance.dump()`.
+- Dump the state of the mock firebase with `FakeFirebaseFirestore.dump()`.
 - Create documents and collections.
 - Create documents with `collection.add` or `document.set`.
 - Batch writes and `runTransaction`.
@@ -95,7 +95,7 @@ See more examples at [cloud_firestore_mocks/example/test/widget_test.dart](https
 
 ## Compatibility table
 
-| cloud_firestore | cloud_firestore_mocks |
+| cloud_firestore | fake_cloud_firestore |
 |-----------------|-----------------------|
 | 2.1.0           | 0.9.0                 |
 | 1.0.0           | 0.7.0                 |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloud Firestore Mocks
+# Fake Cloud Firestore
 [![pub package](https://img.shields.io/pub/v/fake_cloud_firestore.svg)](https://pub.dartlang.org/packages/fake_cloud_firestore)
 
 Fakes to write unit tests for Cloud Firestore. Instantiate a
@@ -53,7 +53,7 @@ const MessagesCollection = 'messages';
 
 void main() {
   testWidgets('shows messages', (WidgetTester tester) async {
-    // Populate the mock database.
+    // Populate the fake database.
     final firestore = FakeFirebaseFirestore();
     await firestore.collection(MessagesCollection).add({
       'message': 'Hello world!',
@@ -78,7 +78,7 @@ See more examples at [fake_cloud_firestore/example/test/widget_test.dart](https:
 
 ## Features
 
-- Dump the state of the mock firebase with `FakeFirebaseFirestore.dump()`.
+- Dump the state of the fake firebase with `FakeFirebaseFirestore.dump()`.
 - Create documents and collections.
 - Create documents with `collection.add` or `document.set`.
 - Batch writes and `runTransaction`.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   test: any
   flutter_driver:
     sdk: flutter
-  cloud_firestore_mocks:
+  fake_cloud_firestore:
     path: ../
 
 flutter:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:firestore_example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,7 +9,7 @@ const MessagesCollection = 'messages';
 void main() {
   testWidgets('shows messages', (WidgetTester tester) async {
     // Populate the mock database.
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     await firestore.collection(MessagesCollection).add({
       'message': 'Hello world!',
       'created_at': FieldValue.serverTimestamp(),
@@ -29,7 +29,7 @@ void main() {
 
   testWidgets('adds messages', (WidgetTester tester) async {
     // Instantiate the mock database.
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
 
     // Render the widget.
     await tester.pumpWidget(MaterialApp(

--- a/lib/fake_cloud_firestore.dart
+++ b/lib/fake_cloud_firestore.dart
@@ -1,8 +1,8 @@
 /// Support for doing something awesome.
 ///
 /// More dartdocs go here.
-library cloud_firestore_mocks;
+library fake_cloud_firestore;
 
-export 'src/cloud_firestore_mocks_base.dart';
+export 'src/fake_cloud_firestore_instance.dart';
 
 // TODO: Export any libraries intended for clients of this package.

--- a/lib/src/fake_cloud_firestore_instance.dart
+++ b/lib/src/fake_cloud_firestore_instance.dart
@@ -11,7 +11,7 @@ import 'mock_field_value_factory_platform.dart';
 import 'mock_write_batch.dart';
 import 'util.dart';
 
-class MockFirestoreInstance implements FirebaseFirestore {
+class FakeFirebaseFirestore implements FirebaseFirestore {
   final _root = <String, dynamic>{};
   final _docsData = <String, dynamic>{};
   final _snapshotStreamControllerRoot = <String, dynamic>{};
@@ -19,7 +19,7 @@ class MockFirestoreInstance implements FirebaseFirestore {
   /// Saved documents' full paths from root. For example:
   /// 'users/abc/friends/foo'
   final Set<String> _savedDocumentPaths = <String>{};
-  MockFirestoreInstance() {
+  FakeFirebaseFirestore() {
     _setupFieldValueFactory();
   }
 
@@ -52,7 +52,7 @@ class MockFirestoreInstance implements FirebaseFirestore {
     final segments = path.split('/');
     // The actual behavior of Firestore for an invalid number of segments
     // differs by platforms. This library imitates it with assert.
-    // https://github.com/atn832/cloud_firestore_mocks/issues/30
+    // https://github.com/atn832/fake_cloud_firestore/issues/30
     assert(segments.length % 2 == 0,
         'Invalid document reference. Document references must have an even number of segments');
     final documentId = segments.last;

--- a/lib/src/mock_collection_reference.dart
+++ b/lib/src/mock_collection_reference.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 
 import 'mock_collection_reference_platform.dart';
@@ -22,7 +22,7 @@ class MockCollectionReference<T extends Object?> extends MockQuery<T>
   final Map<String, dynamic> root;
   final Map<String, dynamic> docsData;
   final Map<String, dynamic> snapshotStreamControllerRoot;
-  final MockFirestoreInstance _firestore;
+  final FakeFirebaseFirestore _firestore;
   final bool _isCollectionGroup;
 
   /// Path from the root to this collection. For example "users/USER0004/friends"

--- a/lib/src/mock_document_change.dart
+++ b/lib/src/mock_document_change.dart
@@ -11,7 +11,7 @@ class MockDocumentChange<T extends Object?> implements DocumentChange<T> {
     this._type, {
     required int oldIndex,
     required int newIndex,
-  })   : _oldIndex = oldIndex,
+  })  : _oldIndex = oldIndex,
         _newIndex = newIndex;
 
   @override

--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -4,7 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 
 import 'mock_document_reference_platform.dart';
-import 'cloud_firestore_mocks_base.dart';
+import 'fake_cloud_firestore_instance.dart';
 import 'mock_collection_reference.dart';
 import 'mock_document_snapshot.dart';
 import 'mock_field_value_platform.dart';
@@ -19,7 +19,7 @@ class MockDocumentReference<T extends Object?> implements DocumentReference<T> {
   final Map<String, dynamic> docsData;
   final Map<String, dynamic> rootParent;
   final Map<String, dynamic> snapshotStreamControllerRoot;
-  final MockFirestoreInstance _firestore;
+  final FakeFirebaseFirestore _firestore;
 
   /// Path from the root to this document. For example "users/USER0004/friends/FRIEND001"
   final String _path;

--- a/lib/src/mock_document_snapshot.dart
+++ b/lib/src/mock_document_snapshot.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/src/mock_snapshot_metadata.dart';
-import 'package:cloud_firestore_mocks/src/util.dart';
+import 'package:fake_cloud_firestore/src/mock_snapshot_metadata.dart';
+import 'package:fake_cloud_firestore/src/util.dart';
 
 import 'util.dart';
 

--- a/lib/src/mock_field_value_factory_platform.dart
+++ b/lib/src/mock_field_value_factory_platform.dart
@@ -1,4 +1,4 @@
-import 'package:cloud_firestore_mocks/src/mock_field_value_platform.dart';
+import 'package:fake_cloud_firestore/src/mock_field_value_platform.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 

--- a/lib/src/mock_query_snapshot.dart
+++ b/lib/src/mock_query_snapshot.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/src/mock_document_change.dart';
+import 'package:fake_cloud_firestore/src/mock_document_change.dart';
 
 import 'mock_query_document_snapshot.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
-name: cloud_firestore_mocks
-description: Fake implementation of Cloud Firestore. Use this package to write unit tests involving Cloud Firestore.
-version: 0.9.0
+name: fake_cloud_firestore
+description: Fake implementation of Cloud Firestore. Use this package to unit test apps that use Cloud Firestore.
+version: 1.0.0
 homepage: http://blog.wafrat.com
-repository: https://github.com/atn832/cloud_firestore_mocks
+repository: https://github.com/atn832/fake_cloud_firestore
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fake_cloud_firestore
-description: Fake implementation of Cloud Firestore. Use this package to unit test apps that use Cloud Firestore.
+description: Previously known as cloud_firestore_mocks. Fake implementation of Cloud Firestore. Use this package to unit test apps that use Cloud Firestore.
 version: 1.0.0
 homepage: http://blog.wafrat.com
 repository: https://github.com/atn832/fake_cloud_firestore

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/services.dart';
 import 'package:test/test.dart';
 
@@ -9,7 +9,7 @@ import 'query_snapshot_matcher.dart';
 const uid = 'abc';
 
 void main() {
-  group('MockFirestoreInstance.dump', () {
+  group('dump', () {
     const expectedDumpAfterset = '''{
   "users": {
     "abc": {
@@ -19,14 +19,14 @@ void main() {
 }''';
 
     test('Sets data for a document within a collection', () async {
-      final instance = MockFirestoreInstance();
+      final instance = FakeFirebaseFirestore();
       await instance.collection('users').doc(uid).set({
         'name': 'Bob',
       });
       expect(instance.dump(), equals(expectedDumpAfterset));
     });
     test('Add adds data', () async {
-      final instance = MockFirestoreInstance();
+      final instance = FakeFirebaseFirestore();
       final doc1 = await instance.collection('messages').add({
         'content': 'hello!',
         'uid': uid,
@@ -60,16 +60,16 @@ void main() {
   });
 
   test('brackets to read a field', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final docRef = instance.doc('users/alice');
     await docRef.set({'name': 'Alice'});
     expect((await docRef.get())['name'], equals('Alice'));
   });
 
   group('adding data through collection reference', () {
-    late MockFirestoreInstance instance;
+    late FakeFirebaseFirestore instance;
     setUp(() {
-      instance = MockFirestoreInstance();
+      instance = FakeFirebaseFirestore();
     });
     test('data with server timestamp', () async {
       // arrange
@@ -88,7 +88,7 @@ void main() {
   });
 
   test('nested calls to set work', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     await firestore
         .collection('userProfiles')
         .doc('a')
@@ -117,7 +117,7 @@ void main() {
         ])));
   });
   test('Snapshots returns a Stream of Snapshots', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
@@ -130,7 +130,7 @@ void main() {
         ])));
   });
   test('Snapshots returns a Stream of Snapshot', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     // await instance.collection('users').doc(uid).set({
     //   'name': 'Bob',
     // });
@@ -152,7 +152,7 @@ void main() {
     });
   });
   test('Snapshots returns a Stream of Snapshot changes', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     const data = {'name': 'Bob'};
     await instance.collection('users').doc(uid).set(data);
     instance.collection('users').snapshots().listen(expectAsync1((snap) {
@@ -165,7 +165,7 @@ void main() {
   });
   test('Snapshots sets exists property to false if the document does not exist',
       () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
@@ -180,7 +180,7 @@ void main() {
 
   test('Snapshots sets exists property to true if the document does  exist',
       () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
@@ -194,7 +194,7 @@ void main() {
   });
 
   test('Document reference path', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final documentReference = instance
         .collection('users')
         .doc('aaa')
@@ -209,7 +209,7 @@ void main() {
   });
 
   test('Document and collection parent', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final documentReference = instance
         .collection('users')
         .doc('aaa')
@@ -227,7 +227,7 @@ void main() {
   });
 
   test('firestore field', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final documentReference =
         instance.collection('users').doc('aaa').collection('friends');
 
@@ -238,7 +238,7 @@ void main() {
   });
 
   test('Document reference equality', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final documentReference1 = instance
         .collection('users')
         .doc('aaa')
@@ -250,7 +250,7 @@ void main() {
   });
 
   test('Creating document reference should not save the document', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').add(<String, dynamic>{'name': 'Foo'});
     final documentReference = instance.collection('users').doc(uid);
 
@@ -264,7 +264,7 @@ void main() {
   });
 
   test('Saving docs in subcollection', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     // Creates 1st document in "users/abc/friends/<id>"
     await instance
         .collection('users')
@@ -292,14 +292,14 @@ void main() {
     await documentReference.set({'name': 'Bar'});
 
     // TODO: Remove the line below once MockQuery defers query execution.
-    // https://github.com/atn832/cloud_firestore_mocks/issues/31
+    // https://github.com/atn832/fake_cloud_firestore/issues/31
     subcollection = instance.collection('users').doc(uid).collection('friends');
     querySnapshot = await subcollection.get();
     expect(querySnapshot.docs, hasLength(2));
   });
 
   test('Saving docs through FirestoreInstance.doc()', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     await instance.doc('users/$uid/friends/xyz').set({
       'name': 'Foo',
@@ -319,7 +319,7 @@ void main() {
 
   test('Nonexistent document should have null data', () async {
     final nonExistentId = 'nonExistentId';
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     final snapshot1 =
         await instance.collection('users').doc(nonExistentId).get();
@@ -330,7 +330,7 @@ void main() {
   });
 
   test('Snapshots returns a Stream of Snapshots upon each change', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     expect(
         instance.collection('users').snapshots(),
         emits(QuerySnapshotMatcher([
@@ -344,7 +344,7 @@ void main() {
   });
   test('Stores DateTime and returns Timestamps', () async {
     // As per Firebase's implementation.
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final now = DateTime.now();
     // Store a DateTime.
     await instance.collection('messages').add({
@@ -365,7 +365,7 @@ void main() {
   });
 
   test('delete', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({
       'username': 'Bob',
     });
@@ -377,7 +377,7 @@ void main() {
 
   group('FieldValue', () {
     test('FieldValue.delete() deletes key values', () async {
-      final firestore = MockFirestoreInstance();
+      final firestore = FakeFirebaseFirestore();
       await firestore.doc('root/foo').set({'flower': 'rose'});
       await firestore.doc('root/foo').set({'flower': FieldValue.delete()});
       final document = await firestore.doc('root/foo').get();
@@ -387,7 +387,7 @@ void main() {
     });
 
     test('FieldValue.serverTimestamp() sets the time', () async {
-      final firestore = MockFirestoreInstance();
+      final firestore = FakeFirebaseFirestore();
       await firestore.collection('users').doc(uid).set({
         'created': FieldValue.serverTimestamp(),
       });
@@ -402,7 +402,7 @@ void main() {
     });
 
     test('FieldValue.increment() increments number', () async {
-      final firestore = MockFirestoreInstance();
+      final firestore = FakeFirebaseFirestore();
       // Empty document before update
       await firestore.collection('messages').doc(uid).set({
         'int': 0,
@@ -431,7 +431,7 @@ void main() {
     });
 
     test('FieldValue.arrayUnion() adds unique items', () async {
-      final firestore = MockFirestoreInstance();
+      final firestore = FakeFirebaseFirestore();
       // Empty document before update
       await firestore.collection('messages').doc(uid).set({
         'array': [1, 2, 3],
@@ -458,7 +458,7 @@ void main() {
     });
 
     test('FieldValue.arrayRemove() removes items', () async {
-      final firestore = MockFirestoreInstance();
+      final firestore = FakeFirebaseFirestore();
       // Empty document before update
       await firestore.collection('messages').doc(uid).set({
         'array': [1, 2, 3],
@@ -487,7 +487,7 @@ void main() {
     });
 
     test('FieldValue in nested objects', () async {
-      final firestore = MockFirestoreInstance();
+      final firestore = FakeFirebaseFirestore();
       final docRef = firestore.collection('MyCollection').doc('MyDocument');
       final batch = firestore.batch();
 
@@ -519,7 +519,7 @@ void main() {
   });
 
   test('set to nested docs', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({
       'foo.bar.baz.username': 'SomeName',
       'foo.bar.created': FieldValue.serverTimestamp()
@@ -547,7 +547,7 @@ void main() {
   });
 
   test('update to nested docs', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     // This field should not be affected by update
     await instance.collection('users').doc(uid).set({
@@ -589,7 +589,7 @@ void main() {
   });
 
   test('update to non-object field', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     await instance.collection('users').doc(uid).set({
       'foo.name': 'String value to be overwritten',
@@ -612,7 +612,7 @@ void main() {
   });
 
   test('Copy on save', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     final messages = firestore.collection('messages');
 
     final array = [
@@ -699,7 +699,7 @@ void main() {
   });
 
   test('auto generate ID', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     final reference1 = firestore.collection('users').doc();
     final document1Id = reference1.id;
     final reference2 = firestore.collection('users').doc();
@@ -723,7 +723,7 @@ void main() {
   });
 
   test('Snapshot before saving data', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     // These docs are not saved
     final nonExistentId = 'salkdjfaarecikvdiko0';
     final snapshot1 =
@@ -740,7 +740,7 @@ void main() {
   });
 
   test('Snapshot should remain after updating data', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     // These docs are not saved
     final reference = firestore.collection('users').doc('foo');
     await reference.set(<String, dynamic>{'name': 'old'});
@@ -763,7 +763,7 @@ void main() {
   });
 
   test('Batch set', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     final foo = firestore.collection('users').doc('foo');
     final bar = firestore.collection('users').doc('bar');
 
@@ -783,7 +783,7 @@ void main() {
   });
 
   test('Batch update', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     final foo = firestore.collection('users').doc('foo');
     await foo.set(<String, dynamic>{'name.firstName': 'OldValue Foo'});
     final bar = firestore.collection('users').doc('bar');
@@ -805,7 +805,7 @@ void main() {
   });
 
   test('Batch delete', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     final foo = firestore.collection('users').doc('foo');
     await foo.set(<String, dynamic>{'name.firstName': 'Foo'});
     final bar = firestore.collection('users').doc('bar');
@@ -828,21 +828,21 @@ void main() {
     expect(nameMap['firstName'], 'Survivor');
   });
 
-  test('MockFirestoreInstance.document with a valid path', () async {
-    final firestore = MockFirestoreInstance();
+  test('FakeFirebaseFirestore.document with a valid path', () async {
+    final firestore = FakeFirebaseFirestore();
     final documentReference = firestore.doc('users/1234');
     expect(documentReference, isNotNull);
   });
 
-  test('MockFirestoreInstance.document with an invalid path', () async {
-    final firestore = MockFirestoreInstance();
+  test('FakeFirebaseFirestore.document with an invalid path', () async {
+    final firestore = FakeFirebaseFirestore();
 
     // This should fail because users (1 segments) and users/1234/friends (3 segments)
     // are a reference to a subcollection, not a document.
     // In real Firestore, the behavior of this error depends on the platforms;
     // in iOS, it's NSInternalInconsistencyException that would terminate
     // the app. This library imitates it with assert().
-    // https://github.com/atn832/cloud_firestore_mocks/issues/30
+    // https://github.com/atn832/fake_cloud_firestore/issues/30
     expect(() => firestore.doc('users'), throwsA(isA<AssertionError>()));
 
     // subcollection
@@ -850,8 +850,8 @@ void main() {
         throwsA(isA<AssertionError>()));
   });
 
-  test('MockFirestoreInstance.collection with an invalid path', () async {
-    final firestore = MockFirestoreInstance();
+  test('FakeFirebaseFirestore.collection with an invalid path', () async {
+    final firestore = FakeFirebaseFirestore();
 
     // This should fail because users/1234 (2 segments) is a reference to a
     // document, not a collection.
@@ -863,7 +863,7 @@ void main() {
   });
 
   test('Transaction set, update, and delete', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     final foo = firestore.collection('messages').doc('foo');
     final bar = firestore.collection('messages').doc('bar');
     final baz = firestore.collection('messages').doc('baz');
@@ -898,7 +898,7 @@ void main() {
   });
 
   test('Transaction update. runTransaction does not return value.', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     const user = {'name': 'Bob'};
     final userDocRef = instance.collection('users').doc();
     await userDocRef.set(user);
@@ -915,7 +915,7 @@ void main() {
   });
 
   test('Transaction: read must come before writes', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     final foo = firestore.collection('messages').doc('foo');
     final bar = firestore.collection('messages').doc('bar');
     await foo.set(<String, dynamic>{'name': 'Foo'});
@@ -937,7 +937,7 @@ void main() {
   });
 
   test('Document snapshot data returns a new instance', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc(uid).set({
       'name': 'Eve',
       'friends': ['Alice', 'Bob'],
@@ -952,7 +952,7 @@ void main() {
   });
 
   test('CollectionGroup get', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     await firestore.doc('foo/foo_1/bar/bar_1').set({'value': '1'});
     await firestore.doc('foo/foo_2/bar/bar_2').set({'value': '2'});
     await firestore.doc('bar/bar_3').set({'value': '3'});
@@ -966,7 +966,7 @@ void main() {
   });
 
   test('CollectionGroup get all at same level', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     await firestore.doc('foo/foo_3/bar/bar_3').set({'value': '3'});
     await firestore.doc('foo/foo_1/bar/bar_1').set({'value': '1'});
     await firestore.doc('foo/foo_2/bar/bar_2').set({'value': '2'});
@@ -980,7 +980,7 @@ void main() {
   });
 
   test('CollectionGroup snapshots', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     await firestore.doc('foo/foo_1/bar/bar_1').set({'value': '1'});
     await firestore.doc('foo/foo_2/bar/bar_2').set({'value': '2'});
     await firestore.doc('bar/bar_3').set({'value': '3'});
@@ -995,7 +995,7 @@ void main() {
   test(
       'A sub-collection and a document property with identical names can coexist',
       () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
 
     // We add a document to a sub-collection. We obviously expect that document
     // to exist, even though intermediate docs/collections don't.

--- a/test/mock_query_test.dart
+++ b/test/mock_query_test.dart
@@ -1,5 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/services.dart';
 import 'package:test/test.dart';
 
@@ -14,7 +14,7 @@ extension ToData<T> on List<QueryDocumentSnapshot<T>> {
 
 void main() {
   test('size', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     expect((await instance.collection('messages').get()).size, 0);
     await instance.collection('messages').add({
       'content': 'hello!',
@@ -23,7 +23,7 @@ void main() {
   });
 
   test('Where(field, isGreaterThan: ...)', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final now = DateTime.now();
     await instance.collection('messages').add({
       'content': 'hello!',
@@ -54,7 +54,7 @@ void main() {
   });
 
   test('isLessThanOrEqualTo', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final now = DateTime.now();
     final before = now.subtract(Duration(seconds: 1));
     final after = now.add(Duration(seconds: 1));
@@ -135,7 +135,7 @@ void main() {
   });
 
   test('isEqualTo, orderBy, limit and getDocuments', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final now = DateTime.now();
     final bookmarks =
         instance.collection('users').doc(uid).collection('bookmarks');
@@ -169,7 +169,7 @@ void main() {
   });
 
   test('isNotEqualTo where clause', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final collection = instance.collection('test');
     await collection.add({'hidden': false, 'id': 'HIDDEN'});
     await collection.add({'hidden': true, 'id': 'VISIBLE'});
@@ -190,7 +190,7 @@ void main() {
   });
 
   test('isNull where clause', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance
         .collection('contestants')
         .add({'name': 'Alice', 'country': 'USA', 'experience': '5'});
@@ -221,7 +221,7 @@ void main() {
   });
 
   test('orderBy returns documents with null fields first', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance
         .collection('usercourses')
         .add({'completed_at': Timestamp.fromDate(DateTime.now())});
@@ -239,7 +239,7 @@ void main() {
   });
 
   test('orderBy returns documents sorted by documentID', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc('3').set({'value': 3});
     await instance.collection('users').doc('2').set({'value': 2});
     await instance.collection('users').doc('1').set({'value': 1});
@@ -256,7 +256,7 @@ void main() {
   });
 
   test('orderBy works with nested values', () async {
-    final firestore = MockFirestoreInstance();
+    final firestore = FakeFirebaseFirestore();
     await firestore.collection('test').add({
       'nested': {
         'value': 5,
@@ -275,7 +275,7 @@ void main() {
   });
 
   test('Where clause resolves composed keys', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('contestants').add({
       'name': 'Alice',
       'country': 'USA',
@@ -308,7 +308,7 @@ void main() {
   });
 
   test('arrayContains', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('posts').add({
       'name': 'Post #1',
       'tags': ['mostrecent', 'interesting'],
@@ -340,7 +340,7 @@ void main() {
   });
 
   test('arrayContainsAny', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('posts').add({
       'name': 'Post #1',
       'tags': ['mostrecent', 'interesting', 'coolstuff'],
@@ -388,7 +388,7 @@ void main() {
   });
 
   test('whereIn', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('contestants').add({
       'name': 'Alice',
       'country': 'USA',
@@ -442,7 +442,7 @@ void main() {
   });
 
   test('where with FieldPath.documentID', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').doc('1').set({'value': 1});
     await instance.collection('users').doc('2').set({'value': 2});
     await instance.collection('users').doc('3').set({'value': 3});
@@ -459,7 +459,7 @@ void main() {
   });
 
   test('Collection.getDocuments', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('users').add({
       'username': 'Bob',
     });
@@ -468,7 +468,7 @@ void main() {
   });
 
   test('Chained where queries return the correct snapshots', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     final bookmarks =
         instance.collection('users').doc(uid).collection('bookmarks');
     await bookmarks.add({
@@ -499,7 +499,7 @@ void main() {
   });
 
   test('Collection reference should not hold query result', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     final collectionReference = instance.collection('users');
     await collectionReference.add({
@@ -510,7 +510,7 @@ void main() {
   });
 
   test('Reference to subcollection should not hold query result', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     final collectionReference = instance.collection('users/1234/friends');
     await collectionReference.doc('abc').set({
@@ -525,7 +525,7 @@ void main() {
   });
 
   test('Query should not hold query result', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     final collectionReference = instance.collection('users/1234/friends');
     final query1 = collectionReference.where('username', isGreaterThan: 'B');
@@ -553,7 +553,7 @@ void main() {
   });
 
   test('StartAfterDocument', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     await instance.collection('messages').doc().set({'Username': 'Alice'});
 
@@ -580,7 +580,7 @@ void main() {
 
   test('chaining where and startAfterDocument return correct documents',
       () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     await instance.collection('messages').doc().set({'username': 'Bob'});
 
@@ -606,7 +606,7 @@ void main() {
   });
 
   test('startAfterDocument throws if the document doesn\'t exist', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     await instance.collection('messages').doc(uid).set({'username': 'Bob'});
 
@@ -627,7 +627,7 @@ void main() {
   });
 
   test('Continuous data receive via stream with where', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     instance
         .collection('messages')
         .where('archived', isEqualTo: false)
@@ -708,7 +708,7 @@ void main() {
       ['bonjour!', 'hello!', 'hola!'],
     ];
 
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     var ascCalled = 0;
     instance
         .collection('messages')
@@ -792,7 +792,7 @@ void main() {
       ['hello!'],
     ];
 
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     var called = 0;
     instance
         .collection('messages')
@@ -836,7 +836,7 @@ void main() {
     // Simple user data
     final testData = {'id': 22, 'username': 'Daniel', 'archived': false};
 
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     // add data to users collection
     await instance.collection('users').add(testData);
@@ -868,7 +868,7 @@ void main() {
       // },
     };
 
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     // add data to users collection
     await instance.collection('users').add(testData);
@@ -885,7 +885,7 @@ void main() {
   });
 
   test('limitToLast', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
     await instance.collection('cities').doc().set({'name': 'Chicago'});
     await instance.collection('cities').doc().set({'name': 'Los Angeles'});
     await instance.collection('cities').doc().set({'name': 'Springfield'});
@@ -907,7 +907,7 @@ void main() {
   });
 
   test('startAt/endAt', () async {
-    final instance = MockFirestoreInstance();
+    final instance = FakeFirebaseFirestore();
 
     await instance.collection('cities').doc().set({
       'name': 'Los Angeles',
@@ -981,7 +981,7 @@ void main() {
     ]);
 
     snapshots = await baseQuery.endAt(['Springfield']).get();
-    // TODO(https://github.com/atn832/cloud_firestore_mocks/issues/166):
+    // TODO(https://github.com/atn832/fake_cloud_firestore/issues/166):
     // The actual Firestore returns:
     // {name: Los Angeles, state: California},
     // {name: Springfield, state: Massachusetts},
@@ -1000,7 +1000,7 @@ void main() {
 
     // Since there is no Springfield, Florida in our docs, it should ignore the second orderBy value
     snapshots = await baseQuery.endAt(['Springfield', 'Florida']).get();
-    // TODO(https://github.com/atn832/cloud_firestore_mocks/issues/167):
+    // TODO(https://github.com/atn832/fake_cloud_firestore/issues/167):
     // the actual Firestore returns {name: Los Angeles, state: California}.
     expect(snapshots.docs.toData(), [
       {

--- a/test/util_test.dart
+++ b/test/util_test.dart
@@ -1,4 +1,4 @@
-import 'package:cloud_firestore_mocks/src/util.dart';
+import 'package:fake_cloud_firestore/src/util.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test_driver/README.md
+++ b/test_driver/README.md
@@ -1,13 +1,13 @@
 # Driver Tests
 
 The `test_driver/cloud_firestore_behaviors` driver test ensures the behavior of 
-cloud_firestore_mocks follows the real Firestore client on a device.
+fake_cloud_firestore follows the real Firestore client on a device.
 
 It runs the same set of assertions for the following three `Firestore` instances:
 
 - cloud_firestore backed by Cloud Firestore (project ID: flutter-firestore)
 - cloud_firestore backed by Firestore emulator
-- cloud_firestore_mocks
+- fake_cloud_firestore
 
 ## Start iOS Simulator
 
@@ -34,7 +34,7 @@ This test does not expect firebase.json; the emulator should run without any sec
 Run Firestore emulator:
 
 ```
-~/Documents/cloud_firestore_mocks $ firebase emulators:start --only firestore
+~/Documents/fake_cloud_firestore $ firebase emulators:start --only firestore
 ...
 ✔  firestore: Emulator started at http://localhost:8080
 ...
@@ -56,11 +56,11 @@ Open another terminal while keeping the emulator running.
 Run the following command in the "example" directory.
 
 ```
-~/Documents/cloud_firestore_mocks $ flutter drive --target=test_driver/cloud_firestore_behaviors.dart
+~/Documents/fake_cloud_firestore $ flutter drive --target=test_driver/cloud_firestore_behaviors.dart
 ...
 flutter: 00:01 +3: Firestore behavior comparison: Unsaved documens (Cloud Firestore)
 flutter: 00:01 +4: Firestore behavior comparison: Unsaved documens (Firestore Emulator)
-flutter: 00:01 +5: Firestore behavior comparison: Unsaved documens (cloud_firestore_mocks)
+flutter: 00:01 +5: Firestore behavior comparison: Unsaved documens (fake_cloud_firestore)
 flutter: 00:01 +6: (tearDownAll)
 flutter: 00:01 +7: All tests passed!
 Stopping application instance.
@@ -74,16 +74,16 @@ for the test cases.
 ### FieldValue tests
 
 The `field_value_behaviors` is a test for FieldValue implementation.
-This test has 2 invocation types. One for cloud_firestore_mocks and the other for
+This test has 2 invocation types. One for fake_cloud_firestore and the other for
 real Firestore and Firestore Emulator backend.
 
 The environment variable `FIRESTORE_IMPLEMENTATION` determines the Cloud Firestore
 implementation.
 
-For `cloud_firestore_mocks`:
+For `fake_cloud_firestore`:
 
 ```
-~/Documents/cloud_firestore_mocks $ FIRESTORE_IMPLEMENTATION=cloud_firestore_mocks flutter drive --target=test_driver/field_value_behaviors.dart
+~/Documents/fake_cloud_firestore $ FIRESTORE_IMPLEMENTATION=fake_cloud_firestore flutter drive --target=test_driver/field_value_behaviors.dart
 ...
 flutter: 00:00 +13: All tests passed!
 Stopping application instance.
@@ -92,7 +92,7 @@ Stopping application instance.
 For `cloud_firestore` (Cloud Firestore and Firestore Emulator):
 
 ```
-~/Documents/cloud_firestore_mocks $ FIRESTORE_IMPLEMENTATION=cloud_firestore flutter drive --target=test_driver/field_value_behaviors.dart
+~/Documents/fake_cloud_firestore $ FIRESTORE_IMPLEMENTATION=cloud_firestore flutter drive --target=test_driver/field_value_behaviors.dart
 ...
 flutter: 00:00 +13: All tests passed!
 Stopping application instance.
@@ -105,11 +105,11 @@ Run this only when you change the assertions in field_value_behavior.dart.
 #### Background: why does this need 2 separate invocations
 
 A Dart runtime cannot use `FieldValue` implementations of both cloud_firestore and
-cloud_firestore_mocks at the same time.
-This is because cloud_firestore_mocks overwrites
+fake_cloud_firestore at the same time.
+This is because fake_cloud_firestore overwrites
 `FieldValueFactoryPlatform.instance` to use a customized `FieldValueFactory` to swap
 FieldValue implementation.
 The instance field updates `static final _factory` field of `FieldValue` class.
 Because the static final field cannot be updated within one Dart runtime, we need
-different `flutter drive` invocations for cloud_firestore and cloud_firestore_mocks.
+different `flutter drive` invocations for cloud_firestore and fake_cloud_firestore.
 

--- a/test_driver/cloud_firestore_behaviors.dart
+++ b/test_driver/cloud_firestore_behaviors.dart
@@ -3,7 +3,7 @@ import 'dart:convert' show utf8;
 import 'dart:typed_data';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,7 +12,7 @@ import 'package:test/test.dart' as _test;
 import 'firestore_clients.dart';
 
 /// Test cases to compare 3 Firestore implementation behaviors: Cloud
-/// Firestore backend, Emulator backend, and cloud_firestore_mocks.
+/// Firestore backend, Emulator backend, and fake_cloud_firestore.
 void main() {
   final completer = Completer<String>();
   enableFlutterDriverExtension(handler: (_) => completer.future);
@@ -26,8 +26,8 @@ void main() {
     'Firestore Emulator':
         createFireStoreClient('test2', 'localhost:8080', false),
 
-    // cloud_firestore_mocks
-    'cloud_firestore_mocks': Future.value(MockFirestoreInstance())
+    // fake_cloud_firestore
+    'fake_cloud_firestore': Future.value(FakeFirebaseFirestore())
   };
 
   group('Firestore behavior comparison:', () {

--- a/test_driver/field_value_behaviors.dart
+++ b/test_driver/field_value_behaviors.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
-import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,9 +9,9 @@ import 'field_value_behaviors_parameters.dart';
 import 'firestore_clients.dart';
 
 /// Test for FieldValue implementation. This test requires
-/// FIRESTORE_IMPLEMENTATION environment variable set to 'cloud_firestore_mocks'
+/// FIRESTORE_IMPLEMENTATION environment variable set to 'fake_cloud_firestore'
 /// or 'cloud_firestore'. For example:
-/// FIRESTORE_IMPLEMENTATION=cloud_firestore_mocks flutter drive --target=test_driver/field_value_behaviors.dart
+/// FIRESTORE_IMPLEMENTATION=fake_cloud_firestore flutter drive --target=test_driver/field_value_behaviors.dart
 void main() async {
   final firestoreImplementationQuery = Completer<String>();
   final completer = Completer<String>();
@@ -35,10 +35,10 @@ void main() async {
   });
 
   firestoreFutures = {
-    // cloud_firestore_mocks
-    'cloud_firestore_mocks': firestoreImplementationQuery.future.then((value) =>
+    // fake_cloud_firestore
+    'fake_cloud_firestore': firestoreImplementationQuery.future.then((value) =>
         value == cloudFirestoreMocksImplementationName
-            ? MockFirestoreInstance()
+            ? FakeFirebaseFirestore()
             : null),
     // cloud_firestore backed by Cloud Firestore (project ID:
     // flutter-firestore)

--- a/test_driver/field_value_behaviors_parameters.dart
+++ b/test_driver/field_value_behaviors_parameters.dart
@@ -1,4 +1,4 @@
-const cloudFirestoreMocksImplementationName = 'cloud_firestore_mocks';
+const cloudFirestoreMocksImplementationName = 'fake_cloud_firestore';
 const cloudFirestoreImplementationName = 'cloud_firestore';
 const validImplementationNames = [
   cloudFirestoreMocksImplementationName,

--- a/test_driver/field_value_behaviors_test.dart
+++ b/test_driver/field_value_behaviors_test.dart
@@ -10,7 +10,7 @@ void main() async {
   if (!validImplementationNames.contains(firestoreImplementation)) {
     throw Exception(
         'Please set environmental varialbe FIRESTORE_IMPLEMENTATION to '
-        'cloud_firestore_mocks or cloud_firestore');
+        'fake_cloud_firestore or cloud_firestore');
   }
 
   final driver = await FlutterDriver.connect();


### PR DESCRIPTION
As per #34. Calling the library a cloud_firestore_mocks and its classes Mock* was misleading.

The migration for users should be effortless:

In pubspec.yaml file, replace `cloud_firestore_mocks: ^0.9.0` by `fake_cloud_firestore: ^1.0.0`.

Then in tests, replace:

```dart
import 'package:cloud_firestore_mocks/cloud_firestore_mocks.dart';

final firestore = MockFirestoreInstance();
```

By:

```dart
import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';

final firestore = FakeFirebaseFirestore();
```
