### PR TITLE
Change `MockDocumentReference.snapshots()` to have asynchronous gap before first event

### DIFF
--- a/lib/src/mock_document_reference.dart
+++ b/lib/src/mock_document_reference.dart
@@ -300,7 +300,11 @@ class MockDocumentReference<T extends Object?>
     bool includeMetadataChanges = false,
     ListenSource? source,
   }) {
-    return snapshotStreamController.stream.startWith(_getSync());
+    return () async* {
+      yield* Stream.fromFuture(Future(() async => _getSync()));
+      yield* snapshotStreamController.stream;
+    }()
+        .asBroadcastStream();
   }
 
   void fireSnapshotUpdate() {

--- a/test/fake_cloud_firestore_test.dart
+++ b/test/fake_cloud_firestore_test.dart
@@ -313,8 +313,7 @@ void main() {
         ),
       );
 
-      //Await the first snapshot to start the stream
-      await allSnapshots.first;
+      await pumpEventQueue();
 
       // Delete the document.
       await docRef.delete();
@@ -357,8 +356,7 @@ void main() {
         ),
       );
 
-      //Await the first snapshot to start the stream
-      await allSnapshots.first;
+      await pumpEventQueue();
 
       // Delete the document.
       await docRef.delete();
@@ -407,12 +405,15 @@ void main() {
             'name': 'Frank',
           }),
         ]));
+    await pumpEventQueue();
     await instance.collection('users').doc(uid).set({
       'name': 'Bob',
     });
+    await pumpEventQueue();
     await instance.collection('users').doc(uid).update({
       'name': 'Frank',
     });
+    await pumpEventQueue();
   });
   test('Snapshots returns a Stream of Snapshot changes', () async {
     final instance = FakeFirebaseFirestore();
@@ -1607,7 +1608,9 @@ void main() {
         ]),
       );
 
+      await pumpEventQueue();
       await docRef.set(Movie()..title = MovieTitle);
+      await pumpEventQueue();
     });
 
     test('snapshot on both the unconverted and converted doc', () async {


### PR DESCRIPTION
Fixes #322 

This introduces the need to call `await pumpEventQueue();` sometimes in tests to correctly emit all changes. I'm not sure if this is desireble

https://github.com/atn832/fake_cloud_firestore/blob/eac203515cda77c1e828132c091e0b5195b70f15/test/fake_cloud_firestore_test.dart#L392-L417