### PR TITLE
fix: update Transaction.update and WriteBatch.update signatures for cloud_firestore 6.2.0

### DIFF
--- a/lib/src/fake_cloud_firestore_instance.dart
+++ b/lib/src/fake_cloud_firestore_instance.dart
@@ -231,7 +231,7 @@ class _DummyTransaction implements Transaction {
 
   @override
   Transaction update(
-      DocumentReference documentReference, Map<String, dynamic> data) {
+      DocumentReference documentReference, Map<Object, Object?> data) {
     _foundWrite = true;
     documentReference.update(data);
     return this;

--- a/lib/src/mock_write_batch.dart
+++ b/lib/src/mock_write_batch.dart
@@ -19,7 +19,7 @@ class MockWriteBatch implements WriteBatch {
   }
 
   @override
-  void update(DocumentReference document, Map<String, dynamic> data) {
+  void update(DocumentReference document, Map<Object, Object?> data) {
     tasks.add(WriteTask()
       ..command = WriteCommand.updateData
       ..document = document


### PR DESCRIPTION
## Summary

`cloud_firestore` 6.2.0 changed the `data` parameter type on `Transaction.update` and `WriteBatch.update` from `Map<String, dynamic>` to `Map<Object, Object?>` (to support `FieldPath` keys, matching `DocumentReference.update` which was already changed earlier).

This PR widens the parameter types in the fake implementations to match.

## Changes

**2 files, 2 lines:**

1. `lib/src/fake_cloud_firestore_instance.dart` (line 234): `Map<String, dynamic>` → `Map<Object, Object?>`
2. `lib/src/mock_write_batch.dart` (line 22): `Map<String, dynamic>` → `Map<Object, Object?>`

## Why this is safe

- `_DummyTransaction.update` passes `data` directly to `documentReference.update()`, which already accepts `Map<Object, Object?>`
- `MockWriteBatch.update` stores `data` in an unparameterized `WriteTask` (`dynamic`), then passes it to `document.update()` in `commit()`
- All existing callers pass `Map<String, dynamic>` literals, which are a subtype of `Map<Object, Object?>`
- `dart analyze` passes cleanly on both changed files

Fixes #334