### PR TITLE
Update firebase dependencies + firebase_auth_mocks: ^0.15.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fake_cloud_firestore
 description: Previously known as cloud_firestore_mocks. Fake implementation of Cloud Firestore. Use this package to unit test apps that use Cloud Firestore.
-version: 4.1.0+1
+version: 4.1.1+1
 homepage: https://www.wafrat.com
 repository: https://github.com/atn832/fake_cloud_firestore
 
@@ -10,8 +10,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  cloud_firestore: ^6.0.0
-  cloud_firestore_platform_interface: ^7.0.0
+  cloud_firestore: ^6.4.0
+  cloud_firestore_platform_interface: ^8.0.0
   collection: ^1.14.13
   plugin_platform_interface: ^2.0.0
   rxdart: ^0.28.0
@@ -27,7 +27,7 @@ dev_dependencies:
   flutter_driver:
     sdk: flutter
   test: ^1.15.2
-  firebase_auth_mocks: ^0.15.0
+  firebase_auth_mocks: ^0.15.2
   flutter_lints: ^6.0.0
 
 false_secrets:


### PR DESCRIPTION
Because of a cross dependency with firebase_auth_mocks (already created a PR there), I assumed the version was going to be ^0.15.2 (feel free to change that). Test sanity check passed, no code change needed. @atn832 