### PR TITLE
fix: get method on FakeAggregateQuery not throwing exception

### DIFF
--- a/lib/src/fake_aggregate_query.dart
+++ b/lib/src/fake_aggregate_query.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
 import 'package:collection/collection.dart';
 import 'package:fake_cloud_firestore/src/aggregate_type_extension.dart';
 import 'package:flutter/foundation.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
 
 import 'fake_aggregate_query_snapshot.dart';
 
@@ -18,6 +19,7 @@ class FakeAggregateQuery implements AggregateQuery {
   @override
   Future<AggregateQuerySnapshot> get(
       {AggregateSource source = AggregateSource.server}) async {
+    maybeThrowException(this, Invocation.method(#get, null, {#source: source}));
     final snapshot = await _query.get();
     final delegate = _getAggregateQuerySnapshotPlatform(snapshot: snapshot);
     return FakeAggregateQuerySnapshot(_query, delegate);

--- a/test/src/fake_aggregate_query_test.dart
+++ b/test/src/fake_aggregate_query_test.dart
@@ -1,7 +1,9 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
 import 'package:fake_cloud_firestore/src/fake_aggregate_query.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mock_exceptions/mock_exceptions.dart';
 
 void main() {
   group('FakeAggregateQuery', () {
@@ -158,6 +160,23 @@ void main() {
         );
         expect(result.whereType<average>().length, 2);
         expect(result.every((e) => e is average), isTrue);
+      });
+    });
+
+    group('exceptions', () {
+      test('get', () async {
+        final firestore = FakeFirebaseFirestore();
+
+        final query = firestore.collection('something').count();
+
+        whenCalling(Invocation.method(#get, null))
+            .on(query)
+            .thenThrow(FirebaseException(plugin: 'firestore'));
+
+        expect(
+          () async => await query.get(),
+          throwsA(isA<FirebaseException>()),
+        );
       });
     });
   });


### PR DESCRIPTION
Hi, i've add maybeThrowException on FakeAggregateQuery's get method.

I actually dont know why the get method on FakeAggregateQuery doesn't throw exception while it calls get method on its internal _query. In my understanding, it could be a MockQuery that have maybeThrowException added or a MockCollectionReference (right now it doesn't have it. I think thats why #321 occurs).

Let me know if you need any changes or maybe also includes fix for issue #321 .